### PR TITLE
[ Feature/common 61 ] 네트워크 오류 시 팝업 컴포넌트

### DIFF
--- a/src/app/error.test.tsx
+++ b/src/app/error.test.tsx
@@ -1,33 +1,56 @@
-import { describe, expect,it } from 'vitest';
+import { http,HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
-import Error from './error';
-import { render, screen, waitFor } from '@testing-library/react';
+import { apiRoutes } from "@shared/constants/apiRoutes";
 
-describe('Error component', () => {
-  it('네트워크 에러 페이지 렌더링', async () => {
+import Error from "./error";
+import { render, screen, waitFor } from "@testing-library/react";
+
+// 네트워크 에러를 반환하는 핸들러 설정
+const server = setupServer(
+  http.get(apiRoutes.problems, async () => {
+    return HttpResponse.json("Service Unavaliable", { status: 404 });
+  }),
+);
+
+// 테스트 실행 전 서버를 시작
+beforeAll(() => server.listen());
+// 각 테스트 후 서버 핸들러를 리셋
+afterEach(() => server.resetHandlers());
+// 모든 테스트 후 서버를 종료
+afterAll(() => server.close());
+
+
+describe("Error component", () => {
+  it("네트워크 에러 페이지 렌더링", async () => {
     const error = { statusCode: 503 };
     render(<Error error={error} />);
-    
+
     await waitFor(() => {
-        expect(screen.getByRole('dialog')).toBeInTheDocument();
-        expect(screen.getByText('네트워크 연결에 실패했어요. 확인 후 다시 시도해주세요.')).toBeInTheDocument();
-        expect(screen.getByText('다시 시도하기')).toBeInTheDocument();
-    })
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "네트워크 연결에 실패했어요. 확인 후 다시 시도해주세요.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText("다시 시도하기")).toBeInTheDocument();
+    });
   });
 
-  it('renders general error message', () => {
-    const error = { statusCode: 400, message: 'Bad Request' };
+  it("renders general error message", () => {
+    const error = { statusCode: 400, message: "Bad Request" };
     render(<Error error={error} />);
-    
-    expect(screen.getByText('문제가 발생했습니다')).toBeInTheDocument();
-    expect(screen.getByText('Bad Request')).toBeInTheDocument();
+
+    expect(screen.getByText("문제가 발생했습니다")).toBeInTheDocument();
+    expect(screen.getByText("Bad Request")).toBeInTheDocument();
   });
 
-  it('renders default error message', () => {
+  it("renders default error message", () => {
     const error = { statusCode: 400 };
     render(<Error error={error} />);
-    
-    expect(screen.getByText('문제가 발생했습니다')).toBeInTheDocument();
-    expect(screen.getByText('잠시 후 다시 시도해 주세요.')).toBeInTheDocument();
+
+    expect(screen.getByText("문제가 발생했습니다")).toBeInTheDocument();
+    expect(screen.getByText("잠시 후 다시 시도해 주세요.")).toBeInTheDocument();
   });
 });

--- a/src/app/error.test.tsx
+++ b/src/app/error.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect,it } from 'vitest';
+
+import Error from './error';
+import { render, screen, waitFor } from '@testing-library/react';
+
+describe('Error component', () => {
+  it('네트워크 에러 페이지 렌더링', async () => {
+    const error = { statusCode: 503 };
+    render(<Error error={error} />);
+    
+    await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText('네트워크 연결에 실패했어요. 확인 후 다시 시도해주세요.')).toBeInTheDocument();
+        expect(screen.getByText('다시 시도하기')).toBeInTheDocument();
+    })
+  });
+
+  it('renders general error message', () => {
+    const error = { statusCode: 400, message: 'Bad Request' };
+    render(<Error error={error} />);
+    
+    expect(screen.getByText('문제가 발생했습니다')).toBeInTheDocument();
+    expect(screen.getByText('Bad Request')).toBeInTheDocument();
+  });
+
+  it('renders default error message', () => {
+    const error = { statusCode: 400 };
+    render(<Error error={error} />);
+    
+    expect(screen.getByText('문제가 발생했습니다')).toBeInTheDocument();
+    expect(screen.getByText('잠시 후 다시 시도해 주세요.')).toBeInTheDocument();
+  });
+});

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState } from "react";
+
+import NetworkError from "@shared/components/NetworkError";
+
+interface ErrorProps {
+  error: {
+    statusCode?: number;
+    message?: string;
+  };
+}
+
+export default function Error({ error }: ErrorProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(true)
+  // 네트워크 오류 상태 코드 확인 (ex: 503, 504 등)
+  const isNetworkError = error.statusCode && error?.statusCode >= 500 && error?.statusCode < 600;
+
+  return (
+    <div>
+      {isNetworkError ? (
+        <NetworkError isOpen={isOpen} setIsOpen={setIsOpen} />
+      ) : (
+        /** TBD: 다른 에러 페이지 커스터마이즈? */
+        <div>
+          <h1>문제가 발생했습니다</h1>
+          <p>{error?.message || '잠시 후 다시 시도해 주세요.'}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/shared/components/NetworkError/index.tsx
+++ b/src/shared/components/NetworkError/index.tsx
@@ -1,0 +1,24 @@
+import { NETWORK_ERROR_MESSAGE } from "@shared/constants/networkError";
+
+import ExternalControlOpenDialog from "../ExternalControlOpenDialog";
+import { Button } from "../ui/button";
+
+interface NetworkErrorProps {
+    isOpen: boolean;
+    setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function NetworkError ({ isOpen, setIsOpen }: NetworkErrorProps) {
+    const titleElement = <div>{NETWORK_ERROR_MESSAGE.CONNECTION_FAIL} <br /> {NETWORK_ERROR_MESSAGE.TRY_AGAIN}</div>
+    const contentElement = <Button onClick={() => location.reload()} className="w-full bg-black text-white" variant={"default"}>다시 시도하기</Button>
+
+    return (
+        <ExternalControlOpenDialog
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+            title={titleElement}
+            content={contentElement}
+        />
+    )
+
+}

--- a/src/shared/constants/networkError.ts
+++ b/src/shared/constants/networkError.ts
@@ -1,0 +1,4 @@
+export const NETWORK_ERROR_MESSAGE = {
+    CONNECTION_FAIL: "네트워크 연결에 실패했어요.",
+    TRY_AGAIN: "확인 후 다시 시도해주세요."
+}


### PR DESCRIPTION
## 🔥 Related Issues
resolve #61 
close #61 

## 💜 작업 내용
- [x] 네트워크 에러 팝업 구현
- [x] 네트워크 에러 테스트 파일 구현

## ✅ PR Point
- shared 폴더에 NetworkError 팝업 컴포넌트 구현했습니다
- 테스트 파일에 직접 아래와 같이 네트워크 에러를 반환하는 핸들러를 넣고, 에러 페이지를 랜더링 해서 확인했는데,, 이 테스트 방법이 맞을까용?? + 이거 빌드 환경에서만 확인 가능한 듯 한데,, 로컬에서 확인 가능한 방법 찾아보겠습니다 😃 
`
// 네트워크 에러를 반환하는 핸들러 설정
const server = setupServer(
  http.get(apiRoutes.problems, async () => {
    return HttpResponse.json("Service Unavaliable", { status: 404 });
  }),
);

// 테스트 실행 전 서버를 시작
beforeAll(() => server.listen());
// 각 테스트 후 서버 핸들러를 리셋
afterEach(() => server.resetHandlers());
// 모든 테스트 후 서버를 종료
afterAll(() => server.close());
`

## 📚 Reference
- https://nextjs.org/docs/app/building-your-application/routing/error-handling
