### PR TITLE
[ Feature/problem 72 ] 문제풀이 완료시 공유팝업 제작

### DIFF
--- a/src/app/problem/[problemId]/page.tsx
+++ b/src/app/problem/[problemId]/page.tsx
@@ -7,6 +7,7 @@ import ProblemExplanation from "@problem/components/ProblemExplanation";
 import ProblemTitle from "@problem/components/ProblemTitle";
 import TagList from "@problem/components/TagList";
 import { ProblemProvider } from "@problem/context/problemContext";
+import ProblemCompleteDialog from "@problem/components/ProblemCompleteDialog";
 export default function ProblemPage() {
   return (
     <ProblemProvider>
@@ -19,6 +20,7 @@ export default function ProblemPage() {
           <ProblemExplanation className="mt-[30px]" />
         </div>
         <AnswerSubmitButton />
+        <ProblemCompleteDialog />
       </>
     </ProblemProvider>
   );

--- a/src/problem/components/ProblemCompleteDialog/ProblemCompleteDialog.test.tsx
+++ b/src/problem/components/ProblemCompleteDialog/ProblemCompleteDialog.test.tsx
@@ -1,0 +1,90 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import QueryClientProviders from "@shared/components/queryClientProvider";
+
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import ProblemCompleteDialog from ".";
+import { useMutation, useMutationState } from "@tanstack/react-query";
+import { postProblemAnswerMutationOptions } from "@problem/remotes/postProblemAnswerOption";
+import { createQueryProviderWrapper } from "@shared/constants/createQueryProvider";
+import { QUERY_KEY } from "@problem/remotes/api";
+import { ApiResponse } from "@api/api-config";
+import { AnswerCheckInfo } from "@problem/types/problemInfo";
+import { LINK_SHARE_CONTENT } from "@common/constants/linkShareContent";
+
+const isExistNextProblem = vi.fn(() => false);
+const renderWithQueryClient = () => {
+  return render(
+    <QueryClientProviders>
+      <ProblemCompleteDialog />
+    </QueryClientProviders>,
+  );
+};
+
+describe("마지막 선택지 제출완료시 팝업 노출 테스트", () => {
+  beforeAll(() => {
+    vi.mock("next/navigation", () => {
+      return {
+        __esModule: true,
+        usePathname: () => "/problem/1",
+        useRouter: () => ({
+          push: vi.fn(),
+          replace: vi.fn(),
+          prefetch: vi.fn(),
+        }),
+        useParams: vi.fn(() => ({
+          problemId: "1",
+        })),
+      };
+    });
+    vi.mock("@common/models/useProblemIdsViewModel", async () => {
+      const actual = await vi.importActual<
+        typeof import("@common/models/useProblemIdsViewModel")
+      >("@common/models/useProblemIdsViewModel");
+      return {
+        ...actual,
+        useProblemIdsViewModel: vi.fn(() => ({
+          isExistNextProblem,
+          nextSetProblemId: vi.fn(),
+          clearProblem: vi.fn(),
+          setProblemIds: vi.fn(),
+          getCurrentProblemId: vi.fn(),
+          getTagCurrentProblemText: vi.fn(() => "3/3"),
+          currentIdx: 0,
+          prevSetProblemId: vi.fn(),
+        })),
+      };
+    });
+  });
+  it("정답 mutation 호출시 팝업 노출 확인, 및 닫기 테스트", async () => {
+    renderWithQueryClient();
+    const { result } = renderHook(
+      () =>
+        useMutation({
+          ...postProblemAnswerMutationOptions({ problemId: "1" }),
+        }),
+      {
+        wrapper: createQueryProviderWrapper(),
+      },
+    );
+
+    act(() => {
+      result.current.mutate({ choiceAns: "2" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBeTruthy());
+
+    expect(
+      screen.getByText(LINK_SHARE_CONTENT.ALL_PROBLEM_SUBMIT.DESCRIPTION),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(LINK_SHARE_CONTENT.ALL_PROBLEM_SUBMIT.TITLE),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/problem/components/ProblemCompleteDialog/index.tsx
+++ b/src/problem/components/ProblemCompleteDialog/index.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { ApiResponse } from "@api/api-config";
+import LinkShare from "@common/components/LinkShare";
+import { LINK_SHARE_CONTENT } from "@common/constants/linkShareContent";
+import { useProblemIdsViewModel } from "@common/models/useProblemIdsViewModel";
+import { QUERY_KEY } from "@problem/remotes/api";
+import { AnswerCheckInfo } from "@problem/types/problemInfo";
+import ExternalControlOpenDialog from "@shared/components/ExternalControlOpenDialog";
+import { useMutationState } from "@tanstack/react-query";
+import { useParams, usePathname } from "next/navigation";
+import React, { useEffect, useState } from "react";
+
+export default function ProblemCompleteDialog() {
+  const pathname = usePathname();
+  const { problemId } = useParams<{ problemId: string }>();
+  const { isExistNextProblem } = useProblemIdsViewModel();
+
+  const problemAnswerInfo = useMutationState({
+    filters: {
+      mutationKey: [QUERY_KEY.POST_PROBLEM_ANSWER, problemId],
+    },
+    select: (mutation) => mutation.state.data as ApiResponse<AnswerCheckInfo>,
+  });
+
+  const isPostAnswerSuccess = problemAnswerInfo[0];
+  const [isOpen, setIsOpen] = useState(
+    isPostAnswerSuccess && !isExistNextProblem(),
+  );
+
+  useEffect(
+    function updateOpenDialog() {
+      setIsOpen(isPostAnswerSuccess && !isExistNextProblem());
+    },
+    [isPostAnswerSuccess],
+  );
+
+  return (
+    <ExternalControlOpenDialog
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      title={
+        <LinkShare.Title title={LINK_SHARE_CONTENT.ALL_PROBLEM_SUBMIT.TITLE} />
+      }
+      description={
+        <LinkShare.Description
+          content={LINK_SHARE_CONTENT.ALL_PROBLEM_SUBMIT.DESCRIPTION}
+        />
+      }
+      content={
+        <LinkShare.Content
+          href={`${process.env.NEXT_PUBLIC_FEW_WEB}${pathname}`}
+        />
+      }
+    />
+  );
+}


### PR DESCRIPTION
## 🔥 Related Issues

resolve #72 
close #72

## 💜 작업 내용

- [x] 문제풀이 완료시 공유 팝업 노출
- [x] 해당 플로우 test code 작성 

## ✅ PR Point
### 📂 problem/components/ProblemCompleteDialog
```ts
const problemAnswerInfo = useMutationState({
    filters: {
      mutationKey: [QUERY_KEY.POST_PROBLEM_ANSWER, problemId],
    },
    select: (mutation) => mutation.state.data as ApiResponse<AnswerCheckInfo>,
  });

  const isPostAnswerSuccess = problemAnswerInfo[0];
  const [isOpen, setIsOpen] = useState(
    isPostAnswerSuccess && !isExistNextProblem(),
  );

// ✅ 정답 제출 mutation 호출 결과 및 마지막 문제인지 조건으로 팝업 오픈
  useEffect(
    function updateOpenDialog() {
      setIsOpen(isPostAnswerSuccess && !isExistNextProblem());
    },
    [isPostAnswerSuccess],
  );
```

### Test code
```ts
  it("정답 mutation 호출시 팝업 노출 확인, 및 닫기 테스트", async () => {
    renderWithQueryClient();
    const { result } = renderHook(
      () =>
        useMutation({
          ...postProblemAnswerMutationOptions({ problemId: "1" }),
        }),
      {
        wrapper: createQueryProviderWrapper(),
      },
    );
  // ✅비동기 함수 호출시, act 사용
    act(() => {
      result.current.mutate({ choiceAns: "2" });
    });

    await waitFor(() => expect(result.current.isSuccess).toBeTruthy());

    expect(
      screen.getByText(LINK_SHARE_CONTENT.ALL_PROBLEM_SUBMIT.DESCRIPTION),
    ).toBeInTheDocument();
    expect(
      screen.getByText(LINK_SHARE_CONTENT.ALL_PROBLEM_SUBMIT.TITLE),
    ).toBeInTheDocument();
  });

```


## 👀 스크린샷 / GIF / 링크
![2024-06-2511 28 39-ezgif com-video-to-gif-converter](https://github.com/YAPP-Github/24th-Web-Team-1-FE/assets/79238676/9739bee3-d1ed-451e-8a52-2ba1d55b9aae)


## 📚 Reference
- [useMutation.test.tsx](https://github.com/marcin-piela/react-fetching-library/blob/master/__tests__/src/hooks/useMutation/useMutation.test.tsx)
