### PR TITLE
[ Feature/workbook 82 ] 커리큘럼 아티클 진입 URL 연결

### DIFF
--- a/src/shared/hooks/useWorkbookId.ts
+++ b/src/shared/hooks/useWorkbookId.ts
@@ -5,7 +5,7 @@ import { getWorkbookId } from '@workbook/utils';
 const useWorkbookId = (pathname: string) => {
   const [workbookId, setWorkbookId] = useState<string>("");
 
-  useEffect(() => {
+  useEffect(function setWorkbookIdByPathname () {
     const id = getWorkbookId(pathname);
     setWorkbookId(id);
   }, [pathname]);

--- a/src/shared/hooks/useWorkbookId.ts
+++ b/src/shared/hooks/useWorkbookId.ts
@@ -1,0 +1,16 @@
+import { useEffect,useState } from 'react';
+
+import { getWorkbookId } from '@workbook/utils';
+
+const useWorkbookId = (pathname: string) => {
+  const [workbookId, setWorkbookId] = useState<string>("");
+
+  useEffect(() => {
+    const id = getWorkbookId(pathname);
+    setWorkbookId(id);
+  }, [pathname]);
+
+  return workbookId;
+};
+
+export default useWorkbookId;

--- a/src/subscription/hooks/useSubscribeForm.tsx
+++ b/src/subscription/hooks/useSubscribeForm.tsx
@@ -1,13 +1,11 @@
 import { usePathname } from 'next/navigation';
 
-import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { useMutation } from '@tanstack/react-query';
 
 import { useToast } from '@shared/components/ui/use-toast';
-
-import { getWorkbookId } from '@workbook/utils';
+import useWorkbookId from '@shared/hooks/useWorkbookId';
 
 import { SUBSCRIBE_USER_ACTIONS } from '@subscription/constants/subscribe';
 import { subscribeWorkbookOptions } from '@subscription/remotes/postSubscriptionQueryOptions';
@@ -19,11 +17,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 export const useSubscribeForm = () => {
   const { toast } = useToast();
   const pathname = usePathname()
-  const [workbookId, setWorkbookId] = useState<string>("")
-
-  useEffect(function getId() {
-    return setWorkbookId(getWorkbookId(pathname));
-  }, [pathname])
+  const workbookId = useWorkbookId(pathname)
   
   const form = useForm<EmailSubscribeFormData>({
     resolver: zodResolver(emailSubscribeSchema),
@@ -38,6 +32,8 @@ export const useSubscribeForm = () => {
   }));
 
   const onSubmit = (values: EmailSubscribeFormData) => {
+    console.log(workbookId);
+    
     try {
       subscribeWorkbook(values, {
         onSuccess: () => {

--- a/src/workbook/components/CurriculumItem/CurriculumItem.test.tsx
+++ b/src/workbook/components/CurriculumItem/CurriculumItem.test.tsx
@@ -1,0 +1,50 @@
+import { usePathname } from 'next/navigation';
+
+import { describe, expect, it, Mock, vi } from 'vitest';
+
+import useWorkbookId from '@shared/hooks/useWorkbookId';
+
+import { CurriculumInfo } from '@workbook/types';
+
+import CurriculumItem from '.';
+import { render } from '@testing-library/react';
+
+// Mock the necessary hooks
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+}));
+
+vi.mock('@shared/hooks/useWorkbookId', () => ({
+  default: vi.fn(),
+}));
+
+describe('CurriculumItem 컴포넌트 테스트', () => {
+  it('CurriculumItem 이 렌더링이 잘 되는지 확인한다.', () => {
+    const mockPathname = '/workbook';
+    const mockWorkbookId = '1';
+    const mockItem: CurriculumInfo = { id: 1, title: 'Test Title' };
+
+    (usePathname as Mock).mockReturnValue(mockPathname);
+    (useWorkbookId as Mock).mockReturnValue(mockWorkbookId);
+
+    const { getByText } = render(<CurriculumItem day={1} item={mockItem} />);
+
+    expect(getByText('Day 1')).toBeInTheDocument();
+    expect(getByText('Test Title')).toBeInTheDocument();
+  });
+
+  it('링크 이동 시 workbookId 를 쿼리 스트링으로 포함하는지 확인한다.', () => {
+    const mockPathname = '/workbook';
+    const mockWorkbookId = '1';
+    const mockItem: CurriculumInfo = { id: 1, title: 'Test Title' };
+
+    (usePathname as Mock).mockReturnValue(mockPathname);
+    (useWorkbookId as Mock).mockReturnValue(mockWorkbookId);
+
+    const { getByRole } = render(<CurriculumItem day={1} item={mockItem} />);
+
+    const link = getByRole('link');
+
+    expect(link).toHaveAttribute('href', '/article/1?workbookId=1');
+  });
+});

--- a/src/workbook/components/CurriculumItem/index.tsx
+++ b/src/workbook/components/CurriculumItem/index.tsx
@@ -1,4 +1,11 @@
+'use client'
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { useEffect, useState } from "react";
+
 import { CurriculumInfo } from "@workbook/types";
+import { getWorkbookId } from "@workbook/utils";
 
 interface CurriculumItemProps {
   day: number;
@@ -6,12 +13,19 @@ interface CurriculumItemProps {
 }
 
 export default function CurriculumItem({ day, item }: CurriculumItemProps) {
+  const pathname = usePathname()
+  const [workbookId, setWorkbookId] = useState<string>("")
+
+  useEffect(function getId() {
+    return setWorkbookId(getWorkbookId(pathname));
+    
+  }, [pathname])
   return (
-    <div className="flex flex-row items-center justify-start space-x-[20px] border-b p-2.5">
+    <Link className="flex flex-row items-center justify-start space-x-[20px] border-b p-2.5" href={`/article/${item.id}?workbookId=${workbookId}`}>
       <span className="text-base font-bold">Day {day}</span>
       <span className="ml-2 overflow-hidden overflow-ellipsis whitespace-nowrap text-base text-text-gray1">
         {item.title}
       </span>
-    </div>
+    </Link>
   );
 }

--- a/src/workbook/components/CurriculumItem/index.tsx
+++ b/src/workbook/components/CurriculumItem/index.tsx
@@ -2,11 +2,9 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import { useEffect, useState } from "react";
+import useWorkbookId from "@shared/hooks/useWorkbookId";
 
 import { CurriculumInfo } from "@workbook/types";
-import { getWorkbookId } from "@workbook/utils";
-
 interface CurriculumItemProps {
   day: number;
   item: CurriculumInfo;
@@ -14,12 +12,8 @@ interface CurriculumItemProps {
 
 export default function CurriculumItem({ day, item }: CurriculumItemProps) {
   const pathname = usePathname()
-  const [workbookId, setWorkbookId] = useState<string>("")
+  const workbookId = useWorkbookId(pathname)
 
-  useEffect(function getId() {
-    return setWorkbookId(getWorkbookId(pathname));
-    
-  }, [pathname])
   return (
     <Link className="flex flex-row items-center justify-start space-x-[20px] border-b p-2.5" href={`/article/${item.id}?workbookId=${workbookId}`}>
       <span className="text-base font-bold">Day {day}</span>


### PR DESCRIPTION
## 🔥 Related Issues

resolve #82 
close #82 

## 💜 작업 내용

- [x] 아티클 url 연결
- [x] workbookId 를 query string 으로 넘겨주기
- [x] useWorkbookId 커스텀 훅으로 로직 재사용
```
import { useEffect,useState } from 'react';

import { getWorkbookId } from '@workbook/utils';

const useWorkbookId = (pathname: string) => {
  const [workbookId, setWorkbookId] = useState<string>("");

  useEffect(() => {
    const id = getWorkbookId(pathname);
    setWorkbookId(id);
  }, [pathname]);

  return workbookId;
};

export default useWorkbookId;
```

## ✅ PR Point
- `/article/:articleId?workbookId=id` 형식으로 링크 이동하도록 했습니다!

## 👀 스크린샷 / GIF / 링크
![스크린샷 2024-06-27 오후 11 19 08](https://github.com/YAPP-Github/24th-Web-Team-1-FE/assets/79344555/7f9c591a-6e96-4866-b268-d771b52819fb)