### PR TITLE
[ 🎾 Test/90 ] 목업 변경으로 인한 테스트 실패 및 이전 에러상황 오류 수정

### DIFF
--- a/src/app/problem/[problemId]/problemFirstIdpage.test.tsx
+++ b/src/app/problem/[problemId]/problemFirstIdpage.test.tsx
@@ -106,21 +106,20 @@ describe("첫 번째 문제풀기 페이지 테스트", () => {
     });
     expect(screen.getByText("1/3")).toBeInTheDocument();
     const choiceAnswerButton = screen.getByRole("button", {
-      name: "높은 운용 비용",
+      name: "찬물을 데우는 시간",
     });
     await userEvent.click(choiceAnswerButton);
     const answerSubmitButton = screen.getByRole("button", {
       name: "정답 제출하기",
     });
     await userEvent.click(answerSubmitButton);
-
     const problemExplanation = screen.getByRole("article");
 
     expect(problemExplanation.childElementCount).toBe(2);
     const explanationParagraphy = screen.getByRole("paragraph");
 
     expect(explanationParagraphy.textContent).toBe(
-      "ETF는 일반적으로 낮은 운용 비용을 특징으로 합니다.이는 ETF가 보통 지수 추종(passive management) 방식으로 운용되기 때문입니다. 지수를 추종하는 전략은 액티브 매니지먼트(active management)에 비해 관리가 덜 복잡하고, 따라서 비용이 낮습니다.",
+      "제임스 와트는 증기를 이용하여 공기를 따뜻하게 만드는 라디에이터를 만들었습니다.",
     );
 
     const nextProblemButton = screen.getByRole("button", {

--- a/src/app/problem/[problemId]/problemLastIdPage.test.tsx
+++ b/src/app/problem/[problemId]/problemLastIdPage.test.tsx
@@ -1,6 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import QueryClientProviders from "@shared/components/queryClientProvider";
 import { createQueryProviderWrapper } from "@shared/constants/createQueryProvider";
@@ -14,7 +22,13 @@ import ProblemContext, {
 } from "@problem/context/problemContext";
 import { getProblemQueryOptions } from "@problem/remotes/getProblemQueryOptions";
 import { ProblemContextInfo } from "@problem/types/problemContextInfo";
-import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const isExistNextProblem = vi.fn(() => false);
@@ -78,6 +92,8 @@ describe("마지막 문제 풀이 페이지 테스트", () => {
   });
 
   beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
     renderWithContext({
       problemContextValue: {
         ...defaultStates,
@@ -91,6 +107,10 @@ describe("마지막 문제 풀이 페이지 테스트", () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("마지막 문제 가져오기 확인", async () => {
     const { result } = renderHook(
       () => useQuery({ ...getProblemQueryOptions({ problemId: "3" }) }),
@@ -100,49 +120,50 @@ describe("마지막 문제 풀이 페이지 테스트", () => {
       expect(result.current.isSuccess).toBe(true);
     });
   });
-  // it("정답 선택 이후 정답 제출하기 버튼 클릭 시, 해설 컴포넌트 잘 노출되고, 로띠 재생이후 메인으로 넘어가기", async () => {
-  //   vi.useFakeTimers();
+  it("정답 선택 이후 정답 제출하기 버튼 클릭 시, 해설 컴포넌트 잘 노출되고, 로띠 재생이후 메인으로 넘어가기", async () => {
+    const { result } = renderHook(
+      () => useQuery({ ...getProblemQueryOptions({ problemId: "3" }) }),
+      { wrapper: createQueryProviderWrapper() },
+    );
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(screen.getByText("3/3")).toBeInTheDocument();
+    const choiceAnswerButton = screen.getByRole("button", {
+      name: "온돌은 바닥 아래에 연기 길이 있다.",
+    });
+    await userEvent.click(choiceAnswerButton);
 
-  //   const { result } = renderHook(
-  //     () => useQuery({ ...getProblemQueryOptions({ problemId: "3" }) }),
-  //     { wrapper: createQueryProviderWrapper() },
-  //   );
-  //   await waitFor(() => {
-  //     expect(result.current.isSuccess).toBe(true);
-  //   });
-  //   expect(screen.getByText("3/3")).toBeInTheDocument();
-  //   const choiceAnswerButton = screen.getByRole("button", {
-  //     name: "정리를해서....",
-  //   });
-  //   await userEvent.click(choiceAnswerButton);
-  //   const answerSubmitButton = screen.getByRole("button", {
-  //     name: "정답 제출하기",
-  //   });
+    const answerSubmitButton = screen.getByRole("button", {
+      name: "정답 제출하기",
+    });
 
-  //   await userEvent.click(answerSubmitButton);
+    await userEvent.click(answerSubmitButton);
 
-  //   const problemExplanation = screen.getByRole("article");
-  //   expect(problemExplanation.childElementCount).toBe(2);
-  //   const explanationParagraphy = screen.getByRole("paragraph");
+    const problemExplanation = screen.getByRole("article");
+    expect(problemExplanation.childElementCount).toBe(2);
+    const explanationParagraphy = screen.getByRole("paragraph");
+    expect(explanationParagraphy.textContent).toBe(
+      "온돌은 바닥 아래에 연기가 지나가는 길이 있는 반면, 하이포코스트는 바닥 아래가 거의 다 뚫려있는 형태입니다.",
+    );
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
 
-  //   expect(explanationParagraphy.textContent).toBe(
-  //     "이 유행어는 개발자 PM 영모님께서 종준이에게 주로 사용하는 말입니다. ",
-  //   );
+    const problemCompleteDialogCloseButton = screen.getByRole("button", {
+      name: "Close",
+    });
+    await userEvent.click(problemCompleteDialogCloseButton);
 
-  //   const problemCompleteDialogCloseButton = screen.getByRole("button", {
-  //     name: "Close",
-  //   });
-  //   await userEvent.click(problemCompleteDialogCloseButton);
+    const nextProblemButton = screen.getByRole("button", {
+      name: "메인으로 가기",
+    });
 
-  //   const nextProblemButton = screen.getByRole("button", {
-  //     name: "메인으로 가기",
-  //   });
+    await userEvent.click(nextProblemButton);
 
-  //   await userEvent.click(nextProblemButton);
+    expect(isExistNextProblem).toBeCalled();
 
-  //   expect(isExistNextProblem).toBeCalled();
-
-  //   expect(clearProblem).toHaveBeenCalledOnce();
-  //   expect(push).toHaveBeenNthCalledWith(1, "/");
-  // });
+    expect(clearProblem).toHaveBeenCalledOnce();
+    expect(push).toHaveBeenNthCalledWith(1, "/workbook/1");
+  });
 });

--- a/src/article/components/ArticleTitle/ArticleTitleOnly.test.tsx
+++ b/src/article/components/ArticleTitle/ArticleTitleOnly.test.tsx
@@ -43,9 +43,9 @@ describe("아티클의 타이틀 영역 데이터 잘 노출되는지 확인", (
     await waitFor(async () => result.current.isSuccess);
     await waitFor(() => {
       const headingTag = screen.getByRole("heading", { level: 1 });
-      expect(headingTag).toHaveTextContent("재태크, 투자 필수 용어 모음집");
+      expect(headingTag).toHaveTextContent("겨울철 노벨상 후보들");
 
-      expect(screen.findByText("안나포")).toBeTruthy();
+      expect(screen.findByText("Fig.1")).toBeTruthy();
     });
   });
 });

--- a/src/problem/components/AnswerChoiceList/AnswerChoiceList.test.tsx
+++ b/src/problem/components/AnswerChoiceList/AnswerChoiceList.test.tsx
@@ -46,9 +46,9 @@ describe("선택지 불러오고, 버튼 클릭으로 버튼 ui 변경", () => {
 
     await waitFor(() => result.current.isSuccess);
 
-    expect(screen.getByText("유동성"));
-    expect(screen.getByText("분산투자"));
-    expect(screen.getByText("높은 운용 비용"));
-    expect(screen.getByText("투명성"));
+    expect(screen.getByText("냄비에 물을 끓이는 번거로움"));
+    expect(screen.getByText("가스를 배기하는 장치의 부족"));
+    expect(screen.getByText("찬물을 데우는 시간"));
+    expect(screen.getByText("온수기의 크기"));
   });
 });

--- a/src/problem/components/ProblemTitle/ProblemTitle.test.tsx
+++ b/src/problem/components/ProblemTitle/ProblemTitle.test.tsx
@@ -50,7 +50,7 @@ describe("퀴즈 정보 불러오기 테스트", () => {
 
         const subHeading = screen.getByRole("heading", { level: 2 });
         expect(subHeading).toHaveTextContent(
-          "ETF(상장지수펀드)의 특징이 아닌것은?",
+          "에드윈 루드가 개량한 최초의 자동 저장 탱크식 가스 온수기는 무엇을 해결했나요?",
         );
       },
       { timeout: 500 },


### PR DESCRIPTION
## 🔥 Related Issues

resolve #90
close #90

## 💜 작업 내용

- [x] 목업데이터 변경으로 테스트 코드 데이터 수정
- [x] 마지막 문제 풀이 시 5초 뒤에 뜨는 팝업 테스트 코드 에러 수정

## ✅ PR Point

### ProblemLastPage.test.tsx
[ 마지막 문제 풀이 이후 해설 노출 뒤, 5초후에 팝업 테스트 ](https://github.com/YAPP-Github/24th-Web-Team-1-FE/pull/77) 오류로 올려놓았던 부분 해결했습니다!!!!드디어... 

```ts
// ✅ 테스트 환경에서 타이머를 실행할수있도록 shouldAdvanceTime속성 -> true로 설정
vi.useFakeTimers({ shouldAdvanceTime: true });

// 1️⃣ 정답제출
   await userEvent.click(answerSubmitButton);

// 2️⃣ 정답 제출 이후에는 해설 노출
    const problemExplanation = screen.getByRole("article");
    expect(problemExplanation.childElementCount).toBe(2);
    const explanationParagraphy = screen.getByRole("paragraph");
    expect(explanationParagraphy.textContent).toBe(
      "온돌은 바닥 아래에 연기가 지나가는 길이 있는 반면, 하이포코스트는 바닥 아래가 거의 다 뚫려있는 형태입니다.",
    );
// 3️⃣ 5초 타이머 시작
    act(() => {
      vi.advanceTimersByTime(5000);
    });

// 4️⃣ 5초 지남이후 링크공유 팝업 노출 테스트
    const problemCompleteDialogCloseButton = screen.getByRole("button", {
      name: "Close",
    });
    await userEvent.click(problemCompleteDialogCloseButton);

    const nextProblemButton = screen.getByRole("button", {
      name: "메인으로 가기",
    });

// ✅ 테스트 종료 이후 time 초기화
  afterEach(() => {
    vi.useRealTimers();
  });
```


## 👀 스크린샷 / GIF / 링크
<img width="496" alt="image" src="https://github.com/YAPP-Github/24th-Web-Team-1-FE/assets/79238676/d4aa31fa-c49d-45bd-a525-cda21540757b">


## 📚 Reference

- [stack over flow](https://stackoverflow.com/questions/78541663/when-do-i-need-to-use-act-when-tests-cause-react-state-updates)
- [vitest- shoudladvancedTimer](https://vitest.dev/config/#faketimers-shouldadvancetime)
