### PR TITLE
[ Feature/subscription 89 ] 구독 취소 페이지 뒤로 돌아가기 (레터로 돌아가기) 구현

### DIFF
--- a/src/app/unsubscribe/UnsubscribePage.test.tsx
+++ b/src/app/unsubscribe/UnsubscribePage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import QueryClientProviders from "@shared/components/queryClientProvider";
 
@@ -6,9 +6,10 @@ import UnsubscribeLayout from "./layout";
 import UnsubscribePage from "./page";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { beforeEach } from "node:test";
 
 const push = vi.fn();
-const back = vi.fn()
+const back = vi.fn();
 
 vi.mock("next/navigation", async () => {
   const actual =
@@ -30,6 +31,31 @@ vi.mock("@subscription/hooks/useArticleInfo", () => ({
 }));
 
 describe("UnsubscribePage 동작 테스트", () => {
+  beforeAll(() => {
+    vi.mock("next/navigation", async () => {
+      const actual =
+        await vi.importActual<typeof import("next/navigation")>(
+          "next/navigation",
+        );
+      return {
+        ...actual,
+        useRouter: vi.fn(() => ({
+          push,
+          back,
+        })),
+      };
+    });
+  });
+
+  beforeEach(() => {
+    vi.mock("@subscription/hooks/useArticleInfo", () => ({
+        useArticleInfo: vi.fn().mockReturnValue({
+          articleId: "123",
+          workbookId: "456",
+        }),
+      }));
+  });
+
   it("Topbar 의 뒤로 가기를 클릭 했을 때 특정 워크북의 아티클 페이지로 이동한다", async () => {
     render(
       <QueryClientProviders>

--- a/src/app/unsubscribe/UnsubscribePage.test.tsx
+++ b/src/app/unsubscribe/UnsubscribePage.test.tsx
@@ -8,6 +8,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const push = vi.fn();
+const back = vi.fn()
 
 vi.mock("next/navigation", async () => {
   const actual =
@@ -16,6 +17,7 @@ vi.mock("next/navigation", async () => {
     ...actual,
     useRouter: vi.fn(() => ({
       push,
+      back,
     })),
   };
 });

--- a/src/app/unsubscribe/UnsubscribePage.test.tsx
+++ b/src/app/unsubscribe/UnsubscribePage.test.tsx
@@ -70,5 +70,6 @@ describe("UnsubscribePage 동작 테스트", () => {
     await user.click(backButton);
 
     expect(push).toHaveBeenCalledWith("/article/123?workbookId=456");
+    expect(back).not.toHaveBeenCalled()
   });
 });

--- a/src/app/unsubscribe/UnsubscribePage.test.tsx
+++ b/src/app/unsubscribe/UnsubscribePage.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+import QueryClientProviders from "@shared/components/queryClientProvider";
+
+import UnsubscribeLayout from "./layout";
+import UnsubscribePage from "./page";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const push = vi.fn();
+
+vi.mock("next/navigation", async () => {
+  const actual =
+    await vi.importActual<typeof import("next/navigation")>("next/navigation");
+  return {
+    ...actual,
+    useRouter: vi.fn(() => ({
+      push,
+    })),
+  };
+});
+
+vi.mock("@subscription/hooks/useArticleInfo", () => ({
+  useArticleInfo: vi.fn().mockReturnValue({
+    articleId: "123",
+    workbookId: "456",
+  }),
+}));
+
+describe("UnsubscribePage 동작 테스트", () => {
+  it("Topbar 의 뒤로 가기를 클릭 했을 때 특정 워크북의 아티클 페이지로 이동한다", async () => {
+    render(
+      <QueryClientProviders>
+        <UnsubscribeLayout>
+          <UnsubscribePage />
+        </UnsubscribeLayout>
+      </QueryClientProviders>,
+    );
+
+    const user = userEvent.setup();
+    const backButton = screen.getByTestId("back-icon");
+    await user.click(backButton);
+
+    expect(push).toHaveBeenCalledWith("/article/123?workbookId=456");
+  });
+});

--- a/src/app/unsubscribe/layout.tsx
+++ b/src/app/unsubscribe/layout.tsx
@@ -1,4 +1,8 @@
+import { useRouter } from "next/navigation";
+
 import React, { ReactNode } from "react";
+
+import { useArticleInfo } from "@subscription/hooks/useArticleInfo";
 
 import TopBar from "@common/components/TopBar";
 
@@ -6,9 +10,17 @@ interface UnsubscribeLayoutProps {
   children: ReactNode;
 }
 export default function UnsubscribeLayout({ children }: UnsubscribeLayoutProps) {
+  const router = useRouter()
+
+  const { articleId, workbookId } = useArticleInfo()
+
+  const handleClickBack = () => {
+    router.push(`/article/${articleId}?workbookId=${workbookId}`)
+  }
+  
   return (
     <section className="mx-[20px] mb-[10px] flex h-auto w-full flex-col justify-between">
-      <TopBar />
+      <TopBar onClick={handleClickBack} />
       {children}
     </section>
   );

--- a/src/app/unsubscribe/layout.tsx
+++ b/src/app/unsubscribe/layout.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useRouter } from "next/navigation";
 
 import React, { ReactNode } from "react";

--- a/src/app/unsubscribe/layout.tsx
+++ b/src/app/unsubscribe/layout.tsx
@@ -16,6 +16,7 @@ export default function UnsubscribeLayout({ children }: UnsubscribeLayoutProps) 
 
   const handleClickBack = () => {
     router.push(`/article/${articleId}?workbookId=${workbookId}`)
+    return
   }
   
   return (

--- a/src/common/components/TopBar/index.tsx
+++ b/src/common/components/TopBar/index.tsx
@@ -12,7 +12,7 @@ export default function TopBar({ onClick }: TopBarProps) {
 
   const onClickBackIcon = (e: React.MouseEvent<HTMLDivElement>) => {
     if (onClick) onClick(e);
-    else back()
+    back()
   };
 
   return (

--- a/src/common/components/TopBar/index.tsx
+++ b/src/common/components/TopBar/index.tsx
@@ -12,11 +12,11 @@ export default function TopBar({ onClick }: TopBarProps) {
 
   const onClickBackIcon = (e: React.MouseEvent<HTMLDivElement>) => {
     if (onClick) onClick(e);
-    back();
+    else back()
   };
 
   return (
-    <div className="flex h-[66px] items-center" onClick={onClickBackIcon}>
+    <div className="flex h-[66px] items-center" onClick={onClickBackIcon} data-testid="back-icon">
       <IcBack />
     </div>
   );

--- a/src/common/components/TopBar/index.tsx
+++ b/src/common/components/TopBar/index.tsx
@@ -12,7 +12,7 @@ export default function TopBar({ onClick }: TopBarProps) {
 
   const onClickBackIcon = (e: React.MouseEvent<HTMLDivElement>) => {
     if (onClick) onClick(e);
-    back()
+    else back()
   };
 
   return (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -38,7 +38,7 @@ export default function middleware(req: NextRequest) {
     const paramsToDelete = Object.values(UNSUB_PARAMS);
 
     // searchParams.delete 반복적으로 호출
-    paramsToDelete.forEach((param) => {
+    paramsToDelete.map((param) => {
       nextUrl.searchParams.delete(param);
     });
     const decodedEmail = decodeURIComponent(email);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,8 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
+import { UNSUB_PARAMS } from "@shared/constants/middlewareConstant";
+
 const withOutAuthList = [];
 const withAuthList = [];
 
@@ -32,16 +34,20 @@ export default function middleware(req: NextRequest) {
 
   /** unsubscribe page 진입 시 이메일, 아티클 아이디, 워크북 아이디 쿠키에 저장하는 로직 */
   if (email && articleId && workbookId) {
-    nextUrl.searchParams.delete("user");
-    nextUrl.searchParams.delete("articleId");
-    nextUrl.searchParams.delete("workbookId");
+    // UNSUB_PARAMS의 값을 배열로 변환하여 처리
+    const paramsToDelete = Object.values(UNSUB_PARAMS);
+
+    // searchParams.delete 반복적으로 호출
+    paramsToDelete.forEach((param) => {
+      nextUrl.searchParams.delete(param);
+    });
     const decodedEmail = decodeURIComponent(email);
 
     // Store the email in a cookie to pass to the page
     const response = NextResponse.redirect(nextUrl);
     response.cookies.set("user-email", decodedEmail);
-    response.cookies.set("articleId", articleId);
-    response.cookies.set("workbookId", workbookId);
+    response.cookies.set(UNSUB_PARAMS.ARTICLE_ID, articleId);
+    response.cookies.set(UNSUB_PARAMS.WORKBOOK_ID, workbookId);
 
     return response;
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,6 +21,8 @@ export default function middleware(req: NextRequest) {
   const nextUrl = req.nextUrl.clone();
   const { pathname, searchParams } = nextUrl;
   const email = searchParams.get("user");
+  const articleId = searchParams.get("articleId");
+  const workbookId = searchParams.get("workbookId");
 
   /** /workbook 으로 진입 시 리다이랙션 */
   if (pathname === "/workbook") {
@@ -28,13 +30,18 @@ export default function middleware(req: NextRequest) {
     return NextResponse.redirect(nextUrl);
   }
 
-  if (email) {
+  /** unsubscribe page 진입 시 이메일, 아티클 아이디, 워크북 아이디 쿠키에 저장하는 로직 */
+  if (email && articleId && workbookId) {
     nextUrl.searchParams.delete("user");
+    nextUrl.searchParams.delete("articleId");
+    nextUrl.searchParams.delete("workbookId");
     const decodedEmail = decodeURIComponent(email);
 
     // Store the email in a cookie to pass to the page
     const response = NextResponse.redirect(nextUrl);
     response.cookies.set("user-email", decodedEmail);
+    response.cookies.set("articleId", articleId);
+    response.cookies.set("workbookId", workbookId);
 
     return response;
   }

--- a/src/shared/constants/middlewareConstant.ts
+++ b/src/shared/constants/middlewareConstant.ts
@@ -1,0 +1,6 @@
+export const UNSUB_PARAMS = {
+  USER: 'user',
+  ARTICLE_ID: 'articleId',
+  WORKBOOK_ID: 'workbookId',
+};
+  

--- a/src/subscription/components/UnsubscribeForm/index.tsx
+++ b/src/subscription/components/UnsubscribeForm/index.tsx
@@ -21,6 +21,7 @@ export default function UnsubscribeForm() {
 
   const handleClickBack = () => {
     router.push(`/article/${articleId}?workbookId=${workbookId}`)
+    return
   }
 
   return (

--- a/src/subscription/components/UnsubscribeForm/index.tsx
+++ b/src/subscription/components/UnsubscribeForm/index.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from "next/navigation";
+
 import { FormProvider } from "react-hook-form";
 
 import { Button } from "@shared/components/ui/button";
@@ -6,12 +8,20 @@ import { cn } from "@shared/utils/cn";
 import { buttonStyle } from "@workbook/constants/buttonStyle";
 
 import { UNSUBSCRIBE_FORM } from "@subscription/constants/unsubscribe";
+import { useArticleInfo } from "@subscription/hooks/useArticleInfo";
 import { useUnsubscribeForm } from "@subscription/hooks/useUnsubscribeForm";
 
 import UnsubscribeFormField from "../UnsubscribeFormField";
 
 export default function UnsubscribeForm() {
   const { form, onSubmit } = useUnsubscribeForm();
+  const router = useRouter()
+
+  const { articleId, workbookId } = useArticleInfo()
+
+  const handleClickBack = () => {
+    router.push(`/article/${articleId}?workbookId=${workbookId}`)
+  }
 
   return (
     <FormProvider {...form}>
@@ -25,6 +35,7 @@ export default function UnsubscribeForm() {
               "border-text-gray3 text-black",
               buttonStyle
             )}
+            onClick={handleClickBack}
           >
             {UNSUBSCRIBE_FORM.BACK}
           </Button>

--- a/src/subscription/constants/unsubscribe.ts
+++ b/src/subscription/constants/unsubscribe.ts
@@ -1,6 +1,6 @@
 export const UNSUBSCRIBE_TITLES = {
-    TITLE_NEWS_LETTER: "FEW 뉴스레터",
-    TITLE_CANCEL: "구독을 취소하시겠어요?"
+    TITLE_NEWS_LETTER: "앞으로 FEW의 모든 뉴스레터를",
+    TITLE_CANCEL: "이메일로 받을 수 없게됩니다."
 }
 
 export const UNSUBSCRIBE_FORM = {

--- a/src/subscription/hooks/useArticleInfo.tsx
+++ b/src/subscription/hooks/useArticleInfo.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react"
+
+import { getCookie } from "@subscription/utils"
+
+export const useArticleInfo = () =>{
+    const [articleId, setArticleId] = useState<string | undefined>(undefined)
+    const [workbookId, setWorkbookId] = useState<string | undefined>(undefined)
+
+    useEffect(function getArticleInfo () {
+        const curArticleId = getCookie('articleId');
+        const curWorkbookId = getCookie('workbookId');
+        setArticleId(curArticleId);
+        setWorkbookId(curWorkbookId)
+    }, [])
+
+    return {
+        articleId, 
+        workbookId
+    }
+}

--- a/src/subscription/hooks/useArticleInfo.tsx
+++ b/src/subscription/hooks/useArticleInfo.tsx
@@ -3,8 +3,8 @@ import { useEffect, useState } from "react"
 import { getCookie } from "@subscription/utils"
 
 export const useArticleInfo = () =>{
-    const [articleId, setArticleId] = useState<string | undefined>(undefined)
-    const [workbookId, setWorkbookId] = useState<string | undefined>(undefined)
+    const [articleId, setArticleId] = useState<string | null>(null)
+    const [workbookId, setWorkbookId] = useState<string | null>(null)
 
     useEffect(function getArticleInfo () {
         const curArticleId = getCookie('articleId');

--- a/src/subscription/hooks/useUnsubscribeForm.tsx
+++ b/src/subscription/hooks/useUnsubscribeForm.tsx
@@ -15,7 +15,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 export const useUnsubscribeForm = () => {
   const { toast } = useToast();
-  const [email, setEmail] = useState<string | undefined>(undefined);
+  const [email, setEmail] = useState<string | null>(null);
 
   useEffect(function getEmailFromCookie() {
     const userEmail = getCookie('user-email');

--- a/src/subscription/hooks/useUnsubscribeForm.tsx
+++ b/src/subscription/hooks/useUnsubscribeForm.tsx
@@ -3,8 +3,6 @@ import { useForm } from "react-hook-form";
 
 import { useMutation } from "@tanstack/react-query";
 
-import { z } from "zod";
-
 import { useToast } from "@shared/components/ui/use-toast";
 
 import { UNSUBSCRIBE_CONFIRM } from "@subscription/constants/unsubscribe";

--- a/src/subscription/remotes/postUnsubscriptionQueryOptions.ts
+++ b/src/subscription/remotes/postUnsubscriptionQueryOptions.ts
@@ -15,7 +15,7 @@ export const unsubscribeWorkbook = (
   return axiosRequest("post", API_ROUTE.UNSUBSCRIBE(), body);
 };
 
-export const unsubscribeWorkbookOptions = (email: string | undefined): UseMutationOptions<
+export const unsubscribeWorkbookOptions = (email: string | null): UseMutationOptions<
   ApiResponse<MessageOnlyResponse>,
   Error,
   UnsubscribeBody

--- a/src/subscription/utils/index.ts
+++ b/src/subscription/utils/index.ts
@@ -1,8 +1,8 @@
-export const getCookie = (name: string): string | undefined => {
+export const getCookie = (name: string): string | null => {
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
   if (parts.length === 2) {
-    return parts.pop()?.split(";").shift();
+    return parts.pop()?.split(";").shift() as string
   }
-  return undefined;
+  return null;
 };


### PR DESCRIPTION
## 🔥 Related Issues

resolve #89 
close #89 

## 💜 작업 내용

- [x] 구독 취소 페이지 진입 시 middleware 에서 articleId, workbookId 를 쿼리 스트링에서 받아서 쿠키에 저장
- [x] 쿠키에 저장 된 articleId, workbookId 를 반환하는 useArticleInfo 커스텀 훅 코드 작성
- [x] Topbar 와 레터로 돌아가기 버튼에 특정 워크북에 속한 아티클 페이지로 이동하도록 handleClick 함수 작성 
- [x] 돌아가기 기능 테스트 코드 작성 

## ✅ PR Point

- useArticleInfo 커스텀 훅 코드를 작성했습니다!
```
import { useEffect, useState } from "react"

import { getCookie } from "@subscription/utils"

export const useArticleInfo = () =>{
    const [articleId, setArticleId] = useState<string | undefined>(undefined)
    const [workbookId, setWorkbookId] = useState<string | undefined>(undefined)

    useEffect(function getArticleInfo () {
        const curArticleId = getCookie('articleId');
        const curWorkbookId = getCookie('workbookId');
        setArticleId(curArticleId);
        setWorkbookId(curWorkbookId)
    }, [])

    return {
        articleId, 
        workbookId
    }
}
```
- 돌아가기 버튼 클릭 시 원하는 아티클 링크로 이동하는지에 대한 테스트 코드를 작성했습니다!
파일: `UnsubscribeForm.test.tsx`, `UnsubscribePage.test.tsx`

