### PR TITLE
[ Bugfix/qa 104 ] 로그 데이터 심기 및 문제 풀이 아이디리스트 없이 진입불가

### DIFF
--- a/src/app/problem/page.tsx
+++ b/src/app/problem/page.tsx
@@ -2,7 +2,8 @@
 
 import { useProblemIdsViewModel } from "@common/models/useProblemIdsViewModel";
 import { getProblemsQueryOptions } from "@problem/remotes/getProblemsQueryOptions";
-import { useQuery } from "@tanstack/react-query";
+import { postLogMutationOptions } from "@shared/remotes/postLogMutationOptions";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
@@ -16,6 +17,10 @@ export default function ProblemPage() {
     ...getProblemsQueryOptions({ articleId }),
   });
 
+  const { mutate: postLog } = useMutation({
+    ...postLogMutationOptions(),
+  });
+
   useEffect(
     function getProblemIds() {
       if (problemData) {
@@ -23,6 +28,7 @@ export default function ProblemPage() {
           problemIds: problemData.problemIds,
           articleId,
         });
+        postLog({ from: "email", to: "solveProblem" });
         push(`/problem/${problemData.problemIds[currentIdx]}`);
       }
     },

--- a/src/article/components/ArticleTitle/index.tsx
+++ b/src/article/components/ArticleTitle/index.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { useParams, useSearchParams } from "next/navigation";
 
 import { useEffect, useRef } from "react";
@@ -18,6 +17,8 @@ import { EVENT_NAME } from "@shared/constants/mixpanel";
 import { Mixpanel } from "@shared/utils/mixpanel";
 import ArticleSkeleton from "../ArticleSkeleton";
 import WriterInfo from "../WriterInfo";
+import { IS_EXIST_PROBLEMS } from "@shared/constants/middlewareConstant";
+import { setCookie } from "cookies-next";
 
 export default function ArticleTitle() {
   const isFirstRender = useRef(false);
@@ -57,6 +58,7 @@ export default function ArticleTitle() {
           articleId,
           day: "day" in articleInfo ? articleInfo.day : undefined,
         });
+      setCookie(IS_EXIST_PROBLEMS, "true");
     },
     [articleInfo],
   );

--- a/src/article/components/EmailContentTemplate/index.tsx
+++ b/src/article/components/EmailContentTemplate/index.tsx
@@ -43,9 +43,11 @@ export default function EmailContentTemplate() {
 
   return (
     <table>
-      <td style={{}}>
-        <tr dangerouslySetInnerHTML={{ __html: content }}></tr>
-      </td>
+      <tbody>
+        <tr style={{}}>
+          <td dangerouslySetInnerHTML={{ __html: content }}></td>
+        </tr>
+      </tbody>
     </table>
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-import { UNSUB_PARAMS } from "@shared/constants/middlewareConstant";
+import {
+  IS_EXIST_PROBLEMS,
+  UNSUB_PARAMS,
+} from "@shared/constants/middlewareConstant";
 
 const withOutAuthList = [];
 const withAuthList = [];
@@ -26,8 +29,10 @@ export default function middleware(req: NextRequest) {
   const articleId = searchParams.get("articleId");
   const workbookId = searchParams.get("workbookId");
 
-  if (pathname === '/') {
-    return NextResponse.redirect("https://fewletter.notion.site/FEW-a87459feb21246b0bc63c68ef6140645");
+  if (pathname === "/") {
+    return NextResponse.redirect(
+      "https://fewletter.notion.site/FEW-a87459feb21246b0bc63c68ef6140645",
+    );
   }
 
   /** /workbook 으로 진입 시 리다이랙션 */
@@ -56,6 +61,15 @@ export default function middleware(req: NextRequest) {
     return response;
   }
 
+  if (pathname.includes("/problem")) {
+    const isProblemIds = req.cookies.get(IS_EXIST_PROBLEMS)?.value === "true";
+
+    if (!isProblemIds) {
+      nextUrl.pathname = "/";
+      return NextResponse.redirect(nextUrl);
+    }
+  }
+
   if (isWithAuth) return withAuth(req);
   if (isWithOutAuth) return withOutAuth(req);
 
@@ -63,5 +77,5 @@ export default function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/unsubscribe/:path*", "/workbook/:path*", "/"],
+  matcher: ["/unsubscribe/:path*", "/workbook/:path*", "/problem/:path*"],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,8 +3,12 @@ import { NextResponse } from "next/server";
 
 import {
   IS_EXIST_PROBLEMS,
+  LOG_PARAMS,
   UNSUB_PARAMS,
 } from "@shared/constants/middlewareConstant";
+import { API_ROUTE } from "@shared/remotes";
+import { LogData } from "@shared/types";
+import { undefined } from "zod";
 
 const withOutAuthList = [];
 const withAuthList = [];
@@ -19,7 +23,7 @@ const withAuth = async (req: NextRequest) => {
   return NextResponse.next();
 };
 
-export default function middleware(req: NextRequest) {
+export default async function middleware(req: NextRequest) {
   const isWithAuth = true;
   const isWithOutAuth = false;
 
@@ -28,6 +32,7 @@ export default function middleware(req: NextRequest) {
   const email = searchParams.get("user");
   const articleId = searchParams.get("articleId");
   const workbookId = searchParams.get("workbookId");
+  const fromEmail = searchParams.get(LOG_PARAMS.FROM_EMAIL);
 
   if (pathname === "/") {
     return NextResponse.redirect(
@@ -61,7 +66,34 @@ export default function middleware(req: NextRequest) {
     return response;
   }
 
+  /** article url 진입시 이메일 로그 쌓는 로직 */
+  if (pathname.includes("/article") && fromEmail) {
+    try {
+      const history: LogData = {
+        from: "email",
+        to: "readArticle",
+      };
+      await fetch(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}${API_ROUTE.LOGS()}`,
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            history: JSON.stringify(history),
+          }),
+        },
+      );
+      nextUrl.searchParams.delete(LOG_PARAMS.FROM_EMAIL);
+      return NextResponse.redirect(nextUrl);
+    } catch (error) {
+      return undefined;
+    }
+  }
   if (pathname.includes("/problem")) {
+    /** problme url 진입시 전역상태 없으면 들어올 수 없게 방어하는 로직 */
     const isProblemIds = req.cookies.get(IS_EXIST_PROBLEMS)?.value === "true";
 
     if (!isProblemIds) {
@@ -77,5 +109,10 @@ export default function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/unsubscribe/:path*", "/workbook/:path*", "/problem/:path*"],
+  matcher: [
+    "/unsubscribe/:path*",
+    "/workbook/:path*",
+    "/problem/:path*",
+    "/article/:path*",
+  ],
 };

--- a/src/problem/components/AnswerSubmitButton/index.tsx
+++ b/src/problem/components/AnswerSubmitButton/index.tsx
@@ -1,18 +1,20 @@
 "use client";
 import { useParams, useRouter } from "next/navigation";
 
-import React, { useContext } from "react";
+import { useContext } from "react";
 
 import { useMutation, useMutationState } from "@tanstack/react-query";
 
 import { Button } from "@shared/components/ui/button";
+import { deleteCookie } from "cookies-next";
 
+import { useProblemIdsViewModel } from "@common/models/useProblemIdsViewModel";
 import { BUTTON_INFO } from "@problem/constants/answerButtonInfo";
 import QuizContext from "@problem/context/problemContext";
 import { QUERY_KEY } from "@problem/remotes/api";
 import { postProblemAnswerMutationOptions } from "@problem/remotes/postProblemAnswerOption";
 import { AnswerCheckInfo } from "@problem/types/problemInfo";
-import { useProblemIdsViewModel } from "@common/models/useProblemIdsViewModel";
+import { IS_EXIST_PROBLEMS } from "@shared/constants/middlewareConstant";
 import { cn } from "@shared/utils/cn";
 
 export default function AnswerSubmitButton() {
@@ -45,9 +47,9 @@ export default function AnswerSubmitButton() {
       push(`/problem/${problemId}`);
     }
     if (problemAnswerInfo[0] && !isExistNextProblem()) {
+      push("/");
       clearProblem();
-      // NOTE : 나중에 메인으로 변경 필요
-      push("/workbook/1");
+      deleteCookie(IS_EXIST_PROBLEMS);
     }
   };
   const isPostAnswerSuccess = problemAnswerInfo[0];

--- a/src/shared/constants/middlewareConstant.ts
+++ b/src/shared/constants/middlewareConstant.ts
@@ -1,6 +1,7 @@
 export const UNSUB_PARAMS = {
-  USER: 'user',
-  ARTICLE_ID: 'articleId',
-  WORKBOOK_ID: 'workbookId',
+  USER: "user",
+  ARTICLE_ID: "articleId",
+  WORKBOOK_ID: "workbookId",
 };
-  
+
+export const IS_EXIST_PROBLEMS = "isProblemIds";

--- a/src/shared/constants/middlewareConstant.ts
+++ b/src/shared/constants/middlewareConstant.ts
@@ -5,3 +5,7 @@ export const UNSUB_PARAMS = {
 };
 
 export const IS_EXIST_PROBLEMS = "isProblemIds";
+
+export const LOG_PARAMS = {
+  FROM_EMAIL: "fromEmail",
+};

--- a/src/shared/remotes/index.ts
+++ b/src/shared/remotes/index.ts
@@ -1,1 +1,7 @@
 // api 통신관련
+export const API_ROUTE = {
+  LOGS: () => `/api/v1/logs`,
+};
+export const QUERY_KEY = {
+  POST_LOG: "post-log",
+};

--- a/src/shared/remotes/postLogMutationOptions.ts
+++ b/src/shared/remotes/postLogMutationOptions.ts
@@ -1,0 +1,27 @@
+import { UseMutationOptions } from "@tanstack/react-query";
+
+import { ApiResponse, axiosRequest } from "@api/api-config";
+
+import { LogData } from "@shared/types";
+import { API_ROUTE, QUERY_KEY } from ".";
+
+export const postLog = (
+  history: PostLogBody,
+): Promise<ApiResponse<unknown>> => {
+  return axiosRequest("post", API_ROUTE.LOGS(), history);
+};
+
+export const postLogMutationOptions = (): UseMutationOptions<
+  ApiResponse<unknown>,
+  Error,
+  PostLogBody
+> => {
+  return {
+    mutationKey: [QUERY_KEY.POST_LOG],
+    mutationFn: (history) => postLog(history),
+  };
+};
+
+type PostLogBody = {
+  history: LogData;
+};

--- a/src/shared/remotes/postLogMutationOptions.ts
+++ b/src/shared/remotes/postLogMutationOptions.ts
@@ -5,23 +5,19 @@ import { ApiResponse, axiosRequest } from "@api/api-config";
 import { LogData } from "@shared/types";
 import { API_ROUTE, QUERY_KEY } from ".";
 
-export const postLog = (
-  history: PostLogBody,
-): Promise<ApiResponse<unknown>> => {
-  return axiosRequest("post", API_ROUTE.LOGS(), history);
+export const postLog = (history: LogData): Promise<ApiResponse<unknown>> => {
+  return axiosRequest("post", API_ROUTE.LOGS(), {
+    history: JSON.stringify(history),
+  });
 };
 
 export const postLogMutationOptions = (): UseMutationOptions<
   ApiResponse<unknown>,
   Error,
-  PostLogBody
+  LogData
 > => {
   return {
     mutationKey: [QUERY_KEY.POST_LOG],
     mutationFn: (history) => postLog(history),
   };
-};
-
-type PostLogBody = {
-  history: LogData;
 };

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,1 +1,5 @@
 //type
+export interface LogData {
+  from: string;
+  to: string;
+}


### PR DESCRIPTION
## 🔥 Related Issues

resolve #104
close #104

## 💜 작업 내용

- [x] 문제풀이 아이디 리스트 없이 진입불가
- [x] 로그데이터 심기


## ✅ PR Point

### 쿠키 활용해 문제페이지 진입 방어 로직 구현

```ts
if (pathname.includes("/problem")) {
    /** problme url 진입시 전역상태 없으면 들어올 수 없게 방어하는 로직 */
    const isProblemIds = req.cookies.get(IS_EXIST_PROBLEMS)?.value === "true";

    if (!isProblemIds) {
      nextUrl.pathname = "/";
      return NextResponse.redirect(nextUrl);
    }
  }
```

### middleware log
- 이메일 -> 아티클 진입 url :  https://www.fewletter.com/articleId/2?fromEmail=true
- 미들웨어에서 로그 전송하였습니다...!

```ts
/** article url 진입시 이메일 로그 쌓는 로직 */
  if (pathname.includes("/article") && fromEmail) {
    try {
      const history: LogData = {
        from: "email",
        to: "readArticle",
      };
      await fetch(
        `${process.env.NEXT_PUBLIC_API_BASE_URL}${API_ROUTE.LOGS()}`,
        {
          method: "POST",
          headers: {
            Accept: "application/json",
            "Content-Type": "application/json",
          },
          body: JSON.stringify({
            history: JSON.stringify(history),
          }),
        },
      );
      nextUrl.searchParams.delete(LOG_PARAMS.FROM_EMAIL);
      return NextResponse.redirect(nextUrl);
    } catch (error) {
      return undefined;
    }
  }
```