### PR TITLE
[ Bugfix/qa 107 ] 문제풀이 완료 팝업 노출 분기 수정

### DIFF
--- a/src/app/problem/[problemId]/problemLastIdPage.test.tsx
+++ b/src/app/problem/[problemId]/problemLastIdPage.test.tsx
@@ -80,7 +80,7 @@ describe("마지막 문제 풀이 페이지 테스트", () => {
           nextSetProblemId: vi.fn(),
           clearProblem,
           setProblemIds: vi.fn(),
-          getCurrentProblemId: vi.fn(),
+          getCurrentProblemId: vi.fn(() => 3),
           getTagCurrentProblemText: vi.fn(() => "3/3"),
           currentIdx: 0,
           prevSetProblemId: vi.fn(),
@@ -162,7 +162,9 @@ describe("마지막 문제 풀이 페이지 테스트", () => {
     await userEvent.click(nextProblemButton);
 
     expect(isExistNextProblem).toBeCalled();
-
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
     expect(clearProblem).toHaveBeenCalledOnce();
     expect(push).toHaveBeenNthCalledWith(1, "/");
   });

--- a/src/problem/components/ProblemCompleteDialog/ProblemCompleteDialog.test.tsx
+++ b/src/problem/components/ProblemCompleteDialog/ProblemCompleteDialog.test.tsx
@@ -5,7 +5,6 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import QueryClientProviders from "@shared/components/queryClientProvider";
 import { createQueryProviderWrapper } from "@shared/constants/createQueryProvider";
 
-import ProblemCompleteDialog from ".";
 import { LINK_SHARE_CONTENT } from "@common/constants/linkShareContent";
 import { mockProblemModuleStore } from "@common/stores/mockZustandStore";
 import { postProblemAnswerMutationOptions } from "@problem/remotes/postProblemAnswerOption";
@@ -16,6 +15,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import ProblemCompleteDialog from ".";
 
 const isExistNextProblem = vi.fn(() => false);
 const renderWithQueryClient = () => {
@@ -58,7 +58,7 @@ describe("마지막 선택지 제출완료시 팝업 노출 테스트", () => {
           nextSetProblemId: vi.fn(),
           clearProblem: vi.fn(),
           setProblemIds: vi.fn(),
-          getCurrentProblemId: vi.fn(),
+          getCurrentProblemId: vi.fn(() => 3),
           getTagCurrentProblemText: vi.fn(() => "3/3"),
           currentIdx: 0,
           prevSetProblemId: vi.fn(),

--- a/src/problem/components/ProblemCompleteDialog/index.tsx
+++ b/src/problem/components/ProblemCompleteDialog/index.tsx
@@ -2,7 +2,7 @@
 
 import { useParams } from "next/navigation";
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useMutationState } from "@tanstack/react-query";
 
@@ -18,7 +18,8 @@ import { AnswerCheckInfo } from "@problem/types/problemInfo";
 
 export default function ProblemCompleteDialog() {
   const { problemId } = useParams<{ problemId: string }>();
-  const { isExistNextProblem, getArticlePathText } = useProblemIdsViewModel();
+  const { isExistNextProblem, getArticlePathText, getCurrentProblemId } =
+    useProblemIdsViewModel();
 
   const problemAnswerInfo = useMutationState({
     filters: {
@@ -31,10 +32,11 @@ export default function ProblemCompleteDialog() {
   const [isOpen, setIsOpen] = useState(
     isPostAnswerSuccess && !isExistNextProblem(),
   );
+  const isLastProblemId = getCurrentProblemId() === Number(problemId);
 
   useEffect(
     function updateOpenDialog() {
-      if (isPostAnswerSuccess && !isExistNextProblem()) {
+      if (isPostAnswerSuccess && !isExistNextProblem() && isLastProblemId) {
         setTimeout(() => {
           setIsOpen(isPostAnswerSuccess && !isExistNextProblem());
         }, 5000);


### PR DESCRIPTION
## 🔥 Related Issues

resolve #107
close #107

## 💜 작업 내용

- [x] 문제풀이 완료 팝업 노출분기 수정
- [x] 테스트 코드 수정 

## ✅ PR Point
### 📂 ProblemCompleteDialog.tsx
- 마지막 문제 풀이 완료 + 다음 문제없을시에만 팝업 노출되도록 분기처리 추가했습니다..!

```ts
const isLastProblemId = getCurrentProblemId() === Number(problemId);

  useEffect(
    function updateOpenDialog() {
      if (isPostAnswerSuccess && !isExistNextProblem() && isLastProblemId) {
        setTimeout(() => {
          setIsOpen(isPostAnswerSuccess && !isExistNextProblem());
        }, 5000);
      }
    },
    [isPostAnswerSuccess],
  );
```
### test code 수정
- return value가 필요한 곳에 새롭게 정의하여 테스트를 통과하도록 구현했습니다...!

```ts
 getCurrentProblemId: vi.fn(() => 3),
         
```
