### PR TITLE
[ Bugfix/DEV-78 ] 로그인 상태에 따른 이벤트 분기 처리 및 테스트 코드 수정

### DIFF
--- a/src/api/fewFetch.ts
+++ b/src/api/fewFetch.ts
@@ -93,9 +93,6 @@ const fetInterceptor: Interceptor = {
   onRequest: (config) => {
     const accessToken = getTokenCookie();
 
-    console.log('access Token ', accessToken);
-    
-
     if (accessToken) {
       config.headers = {
         ...config.headers,

--- a/src/main/components/WorkbookCardList/index.tsx
+++ b/src/main/components/WorkbookCardList/index.tsx
@@ -1,21 +1,26 @@
 import { CategoryClientInfo } from "@common/types/category";
+import { ENTIRE_CATEGORY } from "@main/constants";
 import { WorkbookCardModel } from "@main/models/WorkbookCardModel";
 import { getSubscriptionWorkbooksQueryOptions } from "@main/remotes/getSubscriptionWorkbooksQueryOptions";
 import { getWorkbooksWithCategoryQueryOptions } from "@main/remotes/getWorkbooksWithCategoryQueryOptions";
+import useIsLogin from "@shared/hooks/useIsLogin";
 import { useQueries } from "@tanstack/react-query";
 import WorkbookCard from "../WorkbookCard";
 import WorkbookCardListSkeleton from "../WorkbookCardListSkeleton";
-import { ENTIRE_CATEGORY } from "@main/constants";
 
 export default function WorkbookCardList({
   code,
 }: Partial<CategoryClientInfo>) {
+  const isLogin = useIsLogin();
   const workbookCardList = useQueries({
     queries: [
       getWorkbooksWithCategoryQueryOptions({
         code: code !== undefined ? code : ENTIRE_CATEGORY,
       }),
-      getSubscriptionWorkbooksQueryOptions(),
+      {
+        ...getSubscriptionWorkbooksQueryOptions(),
+        enabled: isLogin,
+      },
     ],
     combine: (result) => {
       const [workbookServerList, workbookSubscriptionInfoList] = result;
@@ -35,10 +40,9 @@ export default function WorkbookCardList({
 
   return (
     <section className="mr-[18px] flex gap-[8px] overflow-x-auto">
-      {workbookCardList &&
-        workbookCardList.map((data, idx) => (
-          <WorkbookCard key={`work-book-card-${idx}`} {...data} />
-        ))}
+      {workbookCardList.map((data, idx) => (
+        <WorkbookCard key={`work-book-card-${idx}`} {...data} />
+      ))}
     </section>
   );
 }

--- a/src/main/components/WorkbookCardsWrapper/workbookcardsWrapper.test.tsx
+++ b/src/main/components/WorkbookCardsWrapper/workbookcardsWrapper.test.tsx
@@ -67,7 +67,16 @@ describe("메인페이지 내 카테고리별 워크북 카드 리스트 테스�
     });
   });
 
-  it("cardtype LEARN 일때, 바텀 버튼 클릭 테스트", async () => {
+  it("로그인 상태이고, cardtype LEARN 일때, 바텀 버튼 클릭 테스트", async () => {
+    vi.mock("@shared/hooks/useIsLogin", async () => {
+      const actual = await vi.importActual<
+        typeof import("@shared/hooks/useIsLogin")
+      >("@shared/hooks/useIsLogin");
+      return {
+        ...actual,
+        isLogin: true,
+      };
+    });
     const { result: workbookListResult } = renderHook(
       () =>
         useQueries({
@@ -75,14 +84,20 @@ describe("메인페이지 내 카테고리별 워크북 카드 리스트 테스�
             getWorkbooksWithCategoryQueryOptions({
               code: ENTIRE_CATEGORY,
             }),
-            getSubscriptionWorkbooksQueryOptions(),
+            {
+              ...getSubscriptionWorkbooksQueryOptions(),
+              enabled: true,
+            },
           ],
         }),
       { wrapper: createQueryProviderWrapper() },
     );
-    await waitFor(() =>
-      expect(workbookListResult.current[0].isSuccess).toBe(true),
-    );
+
+    await waitFor(() => {
+      workbookListResult.current.forEach((value) => {
+        expect(value.isSuccess).toBeTruthy();
+      });
+    });
 
     await waitFor(async () => {
       const day1LearnButton = screen.getByText("Day 1 학습하기");

--- a/src/main/hooks/useWorkbookCardBottomButtonEvent.tsx
+++ b/src/main/hooks/useWorkbookCardBottomButtonEvent.tsx
@@ -3,6 +3,7 @@ import queryClient from "@api/queryClient";
 import useSusbscribeWorkbook from "@common/hooks/useSusbscribeWorkbook";
 import { QUERY_KEY } from "@main/remotes";
 import { WorkbookClientInfo } from "@main/types/workbook";
+import useIsLogin from "@shared/hooks/useIsLogin";
 import { onClickLinkCopy } from "@shared/utils/onClickLinkCopy";
 import { useRouter } from "next/navigation";
 
@@ -14,6 +15,7 @@ export default function useWorkbookCardBottomButtonEvent({
   let handleButtonClick;
   const { push } = useRouter();
   const { postSubscribeWorkbook } = useSusbscribeWorkbook();
+  const isLogin = useIsLogin();
 
   const clickShareButton = () => {
     onClickLinkCopy({
@@ -22,17 +24,21 @@ export default function useWorkbookCardBottomButtonEvent({
   };
 
   const clickSubscribeButton = () => {
-    postSubscribeWorkbook({
-      workbookId: workbookId.toString(),
-      handleSucess: () => {
-        queryClient.refetchQueries({
-          queryKey: [QUERY_KEY.GET_SUBSCRIBE_WORKBOOKS],
-        });
-        queryClient.refetchQueries({
-          queryKey: [QUERY_KEY.GET_WORKBOOKS_WITH_CATEGORY],
-        });
-      },
-    });
+    if (isLogin)
+      postSubscribeWorkbook({
+        workbookId: workbookId.toString(),
+        handleSucess: () => {
+          queryClient.refetchQueries({
+            queryKey: [QUERY_KEY.GET_SUBSCRIBE_WORKBOOKS],
+          });
+          queryClient.refetchQueries({
+            queryKey: [QUERY_KEY.GET_WORKBOOKS_WITH_CATEGORY],
+          });
+        },
+      });
+    else {
+      push("/auth");
+    }
   };
 
   const clickLearnButton = () => {


### PR DESCRIPTION
## 🔥 Related Issues
https://linear.app/fewletter/issue/DEV-78/메인-페이지-워크북-카드-로그인-예외처리-및-테스트-버그-수정

## 💜 작업 내용

- [x] 로그인 여부에 따라 버튼 핸들러 재정의
- [x] 테스트 버그 수정

## ✅ PR Point
### workbookcardsWrapper.test.tsx
- dynamic import 이후의 컴포넌트를 테스트 하기 위해서 await waitfor로 감싸주었습니다.

### 로그인상태에 따른 핸들러 분기처리
- 구독상태일경우, 비로그인시에는 로그인/회원가입 페이지로 이동
```ts
 if (isLogin)
      postSubscribeWorkbook({
        workbookId: workbookId.toString(),
        handleSucess: () => {
          queryClient.refetchQueries({
            queryKey: [QUERY_KEY.GET_SUBSCRIBE_WORKBOOKS],
          });
          queryClient.refetchQueries({
            queryKey: [QUERY_KEY.GET_WORKBOOKS_WITH_CATEGORY],
          });
        },
      });
    else {
      push("/auth");
    }
```

- 워크북 리스트 조회시, 로그인 여부에 따라 구독 쿼리 활성화 여부 제어
```ts
const workbookCardList = useQueries({
    queries: [
      getWorkbooksWithCategoryQueryOptions({
        code: code !== undefined ? code : ENTIRE_CATEGORY,
      }),
      {
        ...getSubscriptionWorkbooksQueryOptions(),
        enabled: isLogin,
      },
```

