### PR TITLE
[ Feature/DEV-81 ] 로그인 여부에 따른 헤더 리스트 변경 및 토큰 접근 상수화

### DIFF
--- a/src/api/fewFetch.ts
+++ b/src/api/fewFetch.ts
@@ -1,3 +1,4 @@
+import { COOKIES } from "@shared/constants/token";
 import { getTokenCookie } from "@shared/utils/getTokenCookie";
 import { setCookie } from "cookies-next";
 
@@ -52,7 +53,7 @@ const processApiResponse = async <T extends object>(
 const refreshAccessToken = async (): Promise<string> => {
   const refreshToken = document.cookie
     .split("; ")
-    .find((row) => row.startsWith("refreshToken="))
+    .find((row) => row.startsWith(`${COOKIES.REFRESH_TOKEN}=`))
     ?.split("=")[1];
 
   if (!refreshToken) {
@@ -76,12 +77,12 @@ const refreshAccessToken = async (): Promise<string> => {
 
   const data = await response.json();
 
-  setCookie("accessToken", data.accessToken, {
+  setCookie(COOKIES.ACCESS_TOKEN, data.accessToken, {
     maxAge: 24 * 60 * 60, // 30 days
     path: "/",
   });
 
-  setCookie("refreshToken", data.refreshToken, {
+  setCookie(COOKIES.REFRESH_TOKEN, data.refreshToken, {
     maxAge: 30 * 24 * 60 * 60, // 30 days
     path: "/",
   });

--- a/src/app/auth/validation/complete/Login.test.tsx
+++ b/src/app/auth/validation/complete/Login.test.tsx
@@ -2,9 +2,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import ValidationCompletePage from "./page";
 import { SIGNUP_COMPLETED } from "@auth/constants/auth";
-import { render, screen,waitFor } from "@testing-library/react";
+import { COOKIES } from "@shared/constants/token";
+import { render, screen, waitFor } from "@testing-library/react";
+import ValidationCompletePage from "./page";
 
 // Mocking useRouter
 const mockPush = vi.fn();
@@ -36,7 +37,7 @@ describe("ValidationCompletePage 페이지 테스트", () => {
         })),
       };
     });
-  })
+  });
 
   beforeEach(() => {
     renderWithClient();
@@ -44,8 +45,12 @@ describe("ValidationCompletePage 페이지 테스트", () => {
 
   it("인증을 완료하고 쿠키를 세팅한다.", async () => {
     await waitFor(() => {
-      expect(document.cookie).toContain("accessToken=accessToken");
-      expect(document.cookie).toContain("refreshToken=refreshToken");
+      expect(document.cookie).toContain(
+        `${COOKIES.ACCESS_TOKEN}=${COOKIES.ACCESS_TOKEN}`,
+      );
+      expect(document.cookie).toContain(
+        `${COOKIES.REFRESH_TOKEN}=${COOKIES.REFRESH_TOKEN}`,
+      );
     });
   });
 

--- a/src/auth/components/LogoutLink/LogoutLink.test.tsx
+++ b/src/auth/components/LogoutLink/LogoutLink.test.tsx
@@ -2,15 +2,16 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import LogoutLink from ".";
+import { COOKIES } from "@shared/constants/token";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { deleteCookie } from "cookies-next";
+import LogoutLink from ".";
 
 const mockPush = vi.fn();
 const mockHandleLogout = vi.fn(() => {
-  deleteCookie("accessToken");
-  deleteCookie("refreshToken");
+  deleteCookie(COOKIES.ACCESS_TOKEN);
+  deleteCookie(COOKIES.REFRESH_TOKEN);
   mockPush("/auth");
 });
 
@@ -55,8 +56,12 @@ describe("LogoutLink 컴포넌트 테스트", () => {
     await user.click(logoutButton);
 
     await waitFor(() => {
-      expect(document.cookie).not.toContain("accessToken=accessToken");
-      expect(document.cookie).not.toContain("refreshToken=refreshToken");
+      expect(document.cookie).not.toContain(
+        `${COOKIES.ACCESS_TOKEN}=${COOKIES.ACCESS_TOKEN}`,
+      );
+      expect(document.cookie).not.toContain(
+        `${COOKIES.REFRESH_TOKEN}=${COOKIES.REFRESH_TOKEN}`,
+      );
       expect(mockPush).toHaveBeenCalledWith("/");
     });
   });

--- a/src/auth/hooks/useAuth.tsx
+++ b/src/auth/hooks/useAuth.tsx
@@ -1,14 +1,15 @@
-"use client"
-import { useEffect } from 'react';
+"use client";
+import { useEffect } from "react";
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation } from "@tanstack/react-query";
 
-import { setCookie } from 'cookies-next';
+import { setCookie } from "cookies-next";
 
-import { ApiResponse } from '@api/fewFetch';
+import { ApiResponse } from "@api/fewFetch";
 
-import { postTokenQueryOptions } from '@auth/remotes/postTokenQueryOption';
-import { tokenResponse } from '@auth/types/auth';
+import { postTokenQueryOptions } from "@auth/remotes/postTokenQueryOption";
+import { tokenResponse } from "@auth/types/auth";
+import { COOKIES } from "@shared/constants/token";
 
 export const useAuth = (auth_token: string) => {
   const { mutate: postToken } = useMutation({
@@ -19,22 +20,22 @@ export const useAuth = (auth_token: string) => {
           if (response?.data?.data) {
             const { accessToken, refreshToken } = response.data.data;
 
-            setCookie('accessToken', accessToken, {
+            setCookie(COOKIES.ACCESS_TOKEN, accessToken, {
               maxAge: 24 * 60 * 60, // 30 days
-              path: '/',
+              path: "/",
             });
 
-            setCookie('refreshToken', refreshToken, {
+            setCookie(COOKIES.REFRESH_TOKEN, refreshToken, {
               maxAge: 30 * 24 * 60 * 60, // 30 days
-              path: '/',
+              path: "/",
             });
           }
         },
         onError: (error) => {
           // 로그인 실패
-          console.error('Authentication failed:', error);
+          console.error("Authentication failed:", error);
         },
-      }
+      },
     ),
   });
 

--- a/src/auth/hooks/useLogout.tsx
+++ b/src/auth/hooks/useLogout.tsx
@@ -9,6 +9,7 @@ import { deleteCookie } from "cookies-next";
 import { ApiResponse } from "@api/fewFetch";
 
 import { logOutMutaionOption } from "@auth/remotes/logoutMembersQueryOption";
+import { COOKIES } from "@shared/constants/token";
 
 export const useLogout = () => {
   const router = useRouter();
@@ -18,8 +19,8 @@ export const useLogout = () => {
     onSuccess: (response: ApiResponse<any>) => {
       if (response.data.message === "성공") {
         // 쿠키 삭제 및 로그인 페이지로 이동
-        deleteCookie("accessToken");
-        deleteCookie("refreshToken");
+        deleteCookie(COOKIES.REFRESH_TOKEN);
+        deleteCookie(COOKIES.ACCESS_TOKEN);
         router.push("/");
         window.location.reload();
       }

--- a/src/main/components/DropDownMenuItemList/index.tsx
+++ b/src/main/components/DropDownMenuItemList/index.tsx
@@ -1,11 +1,18 @@
 import { AUTH_LINK, UNAUTH_LINK } from "@main/constants/dropdownMenu";
+import { COOKIES } from "@shared/constants/token";
 import useIsLogin from "@shared/hooks/useIsLogin";
 import { cn } from "@shared/utils/cn";
+import { tokenParse } from "@shared/utils/tokenParse";
+import { getCookie } from "cookies-next";
 
 export function DropDownMenuItemList() {
   const isLogin = useIsLogin();
+  const token =
+    isLogin && tokenParse(getCookie(COOKIES.ACCESS_TOKEN as string) || "");
+
   const MENU_ITEM_LIST = isLogin ? AUTH_LINK : UNAUTH_LINK;
   const lastIdx = MENU_ITEM_LIST.length - 1;
+
   return (
     <ul className="absolute left-0 top-[66px] z-20 h-screen w-full bg-white">
       {MENU_ITEM_LIST.map(({ title, component }, idx) => (
@@ -17,7 +24,7 @@ export function DropDownMenuItemList() {
             lastIdx !== idx && "border-b-[0.5px] border-text-gray3",
           )}
         >
-          {component({ title })}
+          {component({ title, email: token ? token.memberEmail : undefined })}
         </li>
       ))}
     </ul>

--- a/src/main/components/MainHeader/MainHeader.test.tsx
+++ b/src/main/components/MainHeader/MainHeader.test.tsx
@@ -1,17 +1,51 @@
+import useIsLogin from "@shared/hooks/useIsLogin";
+import { tokenParse } from "@shared/utils/tokenParse";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, it } from "vitest";
-import MainHeader from ".";
+import { getCookie } from "cookies-next";
+import { Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
+const push = vi.fn();
+const back = vi.fn();
+
+import QueryClientProviders from "@shared/components/queryClientProvider";
+import MainHeader from ".";
+vi.mock("@shared/hooks/useIsLogin", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("cookies-next", () => ({
+  getCookie: vi.fn(),
+}));
+vi.mock("@shared/utils/tokenParse", () => ({
+  tokenParse: vi.fn(),
+}));
+vi.mock("next/navigation", async () => {
+  const actual =
+    await vi.importActual<typeof import("next/navigation")>("next/navigation");
+  return {
+    ...actual,
+    useRouter: vi.fn(() => ({
+      push,
+      back,
+    })),
+  };
+});
 const renderComponent = () => {
-  return render(<MainHeader />);
+  return render(
+    <QueryClientProviders>
+      <MainHeader />
+    </QueryClientProviders>,
+  );
 };
 
 describe("헤더 햄버거바 테스트", () => {
   beforeEach(() => {
     renderComponent();
   });
-  it("햄버거 바 노출되고, 클릭하면 메뉴가 나타난다.", async () => {
+  it("햄버거 바 노출되고, 비로그인시, 클릭하면 비로그인 아이템 메뉴가 나타난다.", async () => {
+    (useIsLogin as Mock).mockReturnValue(false);
+
     const hamburgerMenu = screen.getByTestId("hamburger-menu");
 
     await userEvent.click(hamburgerMenu);
@@ -19,9 +53,21 @@ describe("헤더 햄버거바 테스트", () => {
     const loginOrSignup = screen.getByText("로그인 또는 회원가입");
     const withFewWork = screen.getByText("FEW와 협업하려면");
     const instagram = screen.getByText("인스타그램");
-
+    screen.debug();
     const xMenu = screen.getByTestId("x-menu");
 
     await userEvent.click(xMenu);
+  });
+  it("햄버거 바 노출되고, 로그인시, 클릭하면 로그인 아이템 메뉴가 나타난다.", async () => {
+    (useIsLogin as Mock).mockReturnValue(true);
+    (getCookie as Mock).mockReturnValue("mocked_token");
+    (tokenParse as Mock).mockReturnValue({ memberEmail: "test@example.com" });
+
+    const hamburgerMenu = screen.getByTestId("hamburger-menu");
+
+    await userEvent.click(hamburgerMenu);
+
+    expect(screen.getByText("내 이메일"));
+    expect(screen.getByText("test@example.com"));
   });
 });

--- a/src/main/types/dropdownMenu.ts
+++ b/src/main/types/dropdownMenu.ts
@@ -1,4 +1,10 @@
 export interface DropdownMenuItem {
   title: string;
-  component: ({ title }: { title: string }) => JSX.Element;
+  component: ({
+    title,
+    email,
+  }: {
+    title: string;
+    email?: string;
+  }) => JSX.Element;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
+import { COOKIES } from "@shared/constants/token";
 import { articleMiddleware } from "@shared/middlewares/article";
-import { AuthMiddleware } from "@shared/middlewares/auth";
 import { problemMiddleware } from "@shared/middlewares/problem";
 import { unsubscriptionMiddleware } from "@shared/middlewares/subscription";
 import { workbookMiddleware } from "@shared/middlewares/workbook";
@@ -43,10 +43,10 @@ const withOutAuth = async (req: NextRequest) => {
 // NOTE : 인증기반 접근할 수 있는 페이지에 대한 middleware
 const withAuth = async (req: NextRequest) => {
   const url = req.nextUrl.clone();
-  const accessToken = req.cookies.get('accessToken');
+  const accessToken = req.cookies.get(COOKIES.ACCESS_TOKEN);
 
   if (!accessToken) {
-    url.pathname = '/auth';
+    url.pathname = "/auth";
     return NextResponse.redirect(url);
   }
 
@@ -70,6 +70,6 @@ export const config = {
     "/problem/:path*",
     "/article/:path*",
     "/",
-    "/auth/:path*"
+    "/auth/:path*",
   ],
 };

--- a/src/shared/constants/token.ts
+++ b/src/shared/constants/token.ts
@@ -1,0 +1,4 @@
+export const COOKIES = {
+  ACCESS_TOKEN: "accessToken",
+  REFRESH_TOKEN: "refreshToken",
+};

--- a/src/shared/hooks/useIsLogin.ts
+++ b/src/shared/hooks/useIsLogin.ts
@@ -1,13 +1,14 @@
 "use client";
 import { useEffect, useState } from "react";
 
+import { COOKIES } from "@shared/constants/token";
 import { getCookie } from "cookies-next";
 
 const useIsLogin = () => {
   const [isLogin, setIsLogin] = useState(false);
 
   useEffect(function checkIsLogin() {
-    const accessToken = getCookie("accessToken");
+    const accessToken = getCookie(COOKIES.ACCESS_TOKEN);
 
     if (accessToken) {
       setIsLogin(true);

--- a/src/shared/types/token.ts
+++ b/src/shared/types/token.ts
@@ -1,0 +1,4 @@
+export type Token = {
+  memberId: string;
+  memberEmail: string;
+};

--- a/src/shared/utils/getTokenCookie.ts
+++ b/src/shared/utils/getTokenCookie.ts
@@ -1,10 +1,11 @@
+import { COOKIES } from "@shared/constants/token";
 import { getCookie } from "cookies-next";
 
 export const getTokenCookie = () => {
-    const accessTokenFromCookie = getCookie("accessToken")
-    if (accessTokenFromCookie) {
-        return accessTokenFromCookie
-    }
+  const accessTokenFromCookie = getCookie(COOKIES.ACCESS_TOKEN);
+  if (accessTokenFromCookie) {
+    return accessTokenFromCookie;
+  }
 
-    return undefined
-}
+  return undefined;
+};

--- a/src/shared/utils/tokenParse.ts
+++ b/src/shared/utils/tokenParse.ts
@@ -1,0 +1,6 @@
+import { Token } from "@shared/types/token";
+
+export const tokenParse = (token: string): Token => {
+  const base64 = Buffer.from(token.split(".")[1], "base64").toString();
+  return JSON.parse(base64);
+};


### PR DESCRIPTION
## 🔥 Related Issues
https://linear.app/fewletter/issue/DEV-81/메인-헤더-로그인상태일때-이메일-보여주도록-구현

## 💜 작업 내용

- [x] 토큰 파싱함수 구현
- [x] 헤더 테스트 코드 확인

## ✅ PR Point

### 쿠키 접근 키 -> 상수화 적용
```ts
export const COOKIES = {
  ACCESS_TOKEN: "accessToken",
  REFRESH_TOKEN: "refreshToken",
};

```

### 메인 헤더 메뉴리스트 제어
```ts
 const isLogin = useIsLogin();
  const token =
    isLogin && tokenParse(getCookie(COOKIES.ACCESS_TOKEN as string) || "");

  const MENU_ITEM_LIST = isLogin ? AUTH_LINK : UNAUTH_LINK;
  const lastIdx = MENU_ITEM_LIST.length - 1;

  return (
    <ul className="absolute left-0 top-[66px] z-20 h-screen w-full bg-white">
      {MENU_ITEM_LIST.map(({ title, component }, idx) => (
        <li
          key={`link-to-${idx}`}
          className={cn(
            "flex flex-col justify-center",
            "sub2-bold min-h-[66px] w-full px-[20px] py-[10px]",
            lastIdx !== idx && "border-b-[0.5px] border-text-gray3",
          )}
        >
          {component({ title, email: token ? token.memberEmail : undefined })}
        </li>
      ))}
    </ul>
  );
```

![image](https://github.com/user-attachments/assets/8932ec70-16a5-4594-b080-b579210ccaf9)
