### PR TITLE
[ Feature/DEV-85 ] 메인페이지 공유시 few 미리보기 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
     siteName: "FEW",
     locale: "ko_KR",
     type: "website",
-    url: "https://www.fewletter.com/",
+    url: "https://www.fewletter.com",
     images: {
       url: "/fewlogo.svg",
     },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,8 +16,19 @@ import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "FEW",
-  description: "매일 아침마다 경제 아티클과 문제를 보내드려요!",
+  title: "FEW - Just a few minute",
+  description: "퀴즈로 뉴스레터 끝까지 읽기",
+  openGraph: {
+    title: "FEW - Just a few minute",
+    description: "퀴즈로 뉴스레터 끝까지 읽기",
+    siteName: "FEW",
+    locale: "ko_KR",
+    type: "website",
+    url: "https://www.fewletter.com/",
+    images: {
+      url: "/fewlogo.svg",
+    },
+  },
   icons: {
     icon: "/fewlogo.svg",
   },


### PR DESCRIPTION
## 🔥 Related Issues
https://linear.app/fewletter/issue/DEV-85/메인페이지-링크-미리보기-이미지-및-타이틀-구현

## 💜 작업 내용

- [x] layout 에서 meta data 정의


## ✅ PR Point

### layout.tsx
```ts
export const metadata: Metadata = {
  title: "FEW - Just a few minute",
  description: "퀴즈로 뉴스레터 끝까지 읽기",
  openGraph: {
    title: "FEW - Just a few minute",
    description: "퀴즈로 뉴스레터 끝까지 읽기",
    siteName: "FEW",
    locale: "ko_KR",
    type: "website",
    url: "https://www.fewletter.com",
    images: {
      url: "/fewlogo.svg",
    },
  },
  icons: {
    icon: "/fewlogo.svg",
  },
};
```
