### PR TITLE
[ Bugfix/dev 89 ] pending데이터 mutationState 에서 사용하도록 버그 수정

### DIFF
--- a/src/app/auth/validation/page.tsx
+++ b/src/app/auth/validation/page.tsx
@@ -1,17 +1,26 @@
 "use client";
 import { useSearchParams } from "next/navigation";
 
-import SignupProgress from "@auth/components/SignupProgress";
-import { useEmailForm } from "@auth/hooks/useEmailForm";
-import FewLogo from "public/enterlogo.svg";
 import SignupPending from "@auth/components/SignupPending";
+import SignupProgress from "@auth/components/SignupProgress";
+import { QUERY_KEY } from "@auth/remotes/api";
+import { useMutationState } from "@tanstack/react-query";
+import FewLogo from "public/enterlogo.svg";
 
 export default function ValidationPage() {
-  const { isPending } = useEmailForm();
   const searchParams = useSearchParams();
-
   const email = searchParams.get("email");
 
+  const emailMutationState = useMutationState({
+    filters: { mutationKey: [QUERY_KEY.MEMBERS] },
+    select: (mutation) => {
+      return {
+        status: mutation.state.status,
+      };
+    },
+  });
+  const lastPendingIndex = emailMutationState.length - 1;
+  const isPending = emailMutationState[lastPendingIndex]?.status === "pending";
   return (
     <div className="flex h-full flex-col items-center">
       <FewLogo />

--- a/src/auth/components/EmailForm/index.tsx
+++ b/src/auth/components/EmailForm/index.tsx
@@ -15,21 +15,21 @@ import {
   SUBSCRIBE_ANNOUCE,
 } from "@subscription/constants/subscribe";
 
-import { LOGIN_OR_SIGNUP, SIGNUP_FAILED } from "@auth/constants/auth";
+import { LOGIN_OR_SIGNUP } from "@auth/constants/auth";
 import { useEmailForm } from "@auth/hooks/useEmailForm";
 import { useLoginFailToast } from "@auth/hooks/useLoginFailToast";
 
 export default function EmailForm() {
-  const { form, onSubmit, goToPendingPage } = useEmailForm();
+  const { form, onSubmitEmail } = useEmailForm();
   const { handleSubmit, control, formState } = form;
 
   useLoginFailToast();
-  
+
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(goToPendingPage)} className="space-y-8">
+      <form onSubmit={handleSubmit(onSubmitEmail)} className="space-y-8">
         <FormField
-          control={form.control}
+          control={control}
           name="email"
           render={({ field }) => (
             <FormItem>

--- a/src/auth/remotes/postMembersQueryOption.ts
+++ b/src/auth/remotes/postMembersQueryOption.ts
@@ -1,28 +1,25 @@
 import { UseMutationOptions } from "@tanstack/react-query";
 
-import { ApiResponse, fewFetch,FewResponse } from "@api/fewFetch";
+import { ApiResponse, fewFetch } from "@api/fewFetch";
 
-import { apiRoutes } from "@shared/constants/apiRoutes";
-
-import { API_ROUTE, QUERY_KEY } from "./api";
 import { memberSaveBody, memberSaveResponse } from "@auth/types/auth";
-
+import { API_ROUTE, QUERY_KEY } from "./api";
 
 export const memberSave = (
-    body: memberSaveBody
+  body: memberSaveBody,
 ): Promise<ApiResponse<memberSaveResponse>> => {
-    return fewFetch().post(API_ROUTE.MEMBERS(), {
-        body: JSON.stringify(body),
-    })
-}
+  return fewFetch().post(API_ROUTE.MEMBERS(), {
+    body: JSON.stringify(body),
+  });
+};
 
 export const memberSaveOptions = (): UseMutationOptions<
-    ApiResponse<memberSaveResponse>,
-    Error,
-    memberSaveBody
+  ApiResponse<memberSaveResponse>,
+  Error,
+  memberSaveBody
 > => {
-    return {
-        mutationKey: [QUERY_KEY.MEMBERS],
-        mutationFn: (body) => memberSave(body),
-    }
-}
+  return {
+    mutationKey: [QUERY_KEY.MEMBERS],
+    mutationFn: (body) => memberSave(body),
+  };
+};


### PR DESCRIPTION
## 🔥 Related Issues
https://linear.app/fewletter/issue/DEV-89/이메일-전송-후-로딩바-구현

## 💜 작업 내용

- [x] pending -> 스코프가 커스텀훅 내부이기에, false로 고정되는 버그 수정


## ✅ PR Point
```ts
// submit 이후 mutataionState 가져와서 pending 상태 보여주도록 수정
  const emailMutationState = useMutationState({
    filters: { mutationKey: [QUERY_KEY.MEMBERS] },
    select: (mutation) => {
      return {
        status: mutation.state.status,
      };
    },
  });
  const lastPendingIndex = emailMutationState.length - 1;
  const isPending = emailMutationState[lastPendingIndex]?.status === "pending";
 
```
