### PR TITLE
[ Feature/dev 97 ] 퀴즈에서 아티클로 다시 넘어가기

### DIFF
--- a/src/app/article/[articleId]/layout.tsx
+++ b/src/app/article/[articleId]/layout.tsx
@@ -13,10 +13,8 @@ export default function ArticlePageLayout({
   return (
     <main className="flex h-auto w-full">
       <section className="flex h-auto w-full flex-col justify-between">
-        <div className="mx-[20px] mb-[10px] flex flex-col">
-          <TopBar />
-          {children}
-        </div>
+        <TopBar className="px-[20px]" />
+        <div className="mx-[20px] mb-[10px] flex flex-col">{children}</div>
         <ArticleBottomButton title={"문제풀기"} />
       </section>
     </main>

--- a/src/app/problem/[problemId]/layout.tsx
+++ b/src/app/problem/[problemId]/layout.tsx
@@ -1,4 +1,5 @@
 import AnswerSubmitButton from "@problem/components/AnswerSubmitButton";
+import BackToArticle from "@problem/components/BackToArticle";
 import ProblemCompleteDialog from "@problem/components/ProblemCompleteDialog";
 import ProblemTopbar from "@problem/components/ProblemTopbar";
 import { ProblemProvider } from "@problem/context/problemContext";
@@ -16,7 +17,10 @@ export default function ProblemLayout({ children }: ProblemLayoutProps) {
             <ProblemTopbar />
             {children}
           </div>
-          <AnswerSubmitButton />
+          <div className="flex flex-col gap-y-[24px]">
+            <BackToArticle />
+            <AnswerSubmitButton />
+          </div>
           <ProblemCompleteDialog />
         </section>
       </ProblemProvider>

--- a/src/app/problem/[problemId]/page.tsx
+++ b/src/app/problem/[problemId]/page.tsx
@@ -1,4 +1,5 @@
 import AnswerChoiceList from "@problem/components/AnswerChoiceList";
+import ArticleDropDownWrapper from "@problem/components/ArticleDropDownWrapper";
 import LottieWithContext from "@problem/components/LottieWithContext";
 import ProblemExplanation from "@problem/components/ProblemExplanation";
 import ProblemTagList from "@problem/components/ProblemTagList";

--- a/src/app/problem/[problemId]/problemFirstIdpage.test.tsx
+++ b/src/app/problem/[problemId]/problemFirstIdpage.test.tsx
@@ -16,6 +16,7 @@ import { render, renderHook, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ProblemLayout from "./layout";
 import ProblemPage from "./page";
+import { BACK_TO_ARTICLE_WORDS } from "@problem/constants/backToArticle";
 
 const isExistNextProblem = vi.fn(() => true);
 const nextSetProblemId = vi.fn(() => "2");
@@ -94,6 +95,8 @@ describe("첫 번째 문제풀기 페이지 테스트", () => {
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
     });
+
+    expect(screen.getByText(BACK_TO_ARTICLE_WORDS.BEFORE)).toBeInTheDocument();
   });
 
   it("정답 선택 이후 정답 제출하기 버튼 클릭 시, 해설 컴포넌트 잘 노출되고, 다음 문제로 넘어가기 확인", async () => {
@@ -117,6 +120,8 @@ describe("첫 번째 문제풀기 페이지 테스트", () => {
 
     expect(problemExplanation.childElementCount).toBe(2);
     const explanationParagraphy = screen.getByRole("paragraph");
+
+    expect(screen.getByText(BACK_TO_ARTICLE_WORDS.AFTER)).toBeInTheDocument();
 
     expect(explanationParagraphy.textContent).toBe(
       "제임스 와트는 증기를 이용하여 공기를 따뜻하게 만드는 라디에이터를 만들었습니다.",

--- a/src/app/problem/[problemId]/problemLastIdPage.test.tsx
+++ b/src/app/problem/[problemId]/problemLastIdPage.test.tsx
@@ -30,6 +30,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import ProblemLayout from "./layout";
 import ProblemPage from "./page";
+import { BACK_TO_ARTICLE_WORDS } from "@problem/constants/backToArticle";
 
 const isExistNextProblem = vi.fn(() => false);
 const clearProblem = vi.fn();
@@ -119,6 +120,8 @@ describe("마지막 문제 풀이 페이지 테스트", () => {
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
     });
+
+    expect(screen.getByText(BACK_TO_ARTICLE_WORDS.BEFORE)).toBeInTheDocument();
   });
   it("정답 선택 이후 정답 제출하기 버튼 클릭 시, 해설 컴포넌트 잘 노출되고, 로띠 재생이후 메인으로 넘어가기", async () => {
     const { result } = renderHook(
@@ -146,6 +149,9 @@ describe("마지막 문제 풀이 페이지 테스트", () => {
     expect(explanationParagraphy.textContent).toBe(
       "온돌은 바닥 아래에 연기가 지나가는 길이 있는 반면, 하이포코스트는 바닥 아래가 거의 다 뚫려있는 형태입니다.",
     );
+
+    expect(screen.getByText(BACK_TO_ARTICLE_WORDS.AFTER)).toBeInTheDocument();
+    
     act(() => {
       vi.advanceTimersByTime(5000);
     });

--- a/src/app/workbook/[id]/layout.tsx
+++ b/src/app/workbook/[id]/layout.tsx
@@ -35,9 +35,7 @@ export default async function WorkbookLayout({
     <HydrationBoundary state={state}>
       <section className="flex h-auto w-full flex-col justify-between">
         <div className="mb-[10px] flex flex-col">
-          <div className="mx-[20px]">
-            <TopBar />
-          </div>
+          <TopBar className="px-[20px]" />
           {children}
         </div>
       </section>

--- a/src/common/components/CancelButton/index.tsx
+++ b/src/common/components/CancelButton/index.tsx
@@ -7,7 +7,7 @@ interface CancelButtonProps {
 export default function CancelButton({ handleToggle }: CancelButtonProps) {
   return (
     <div className="">
-        <XIcon width={36} height={36} className="mr-[23px]" onClick={handleToggle} />
+        <XIcon data-testid="x-menu" width={36} height={36} className="mr-[23px]" onClick={handleToggle} />
     </div>
   )
 }

--- a/src/common/components/CancelButton/index.tsx
+++ b/src/common/components/CancelButton/index.tsx
@@ -1,12 +1,15 @@
 import { XIcon } from "lucide-react";
+import { HTMLAttributes } from "react";
 
-interface CancelButtonProps {
+interface CancelButtonProps extends HTMLAttributes<HTMLDivElement> {
   handleToggle: () => void;
 }
 
-export default function CancelButton({ handleToggle }: CancelButtonProps) {
+export default function CancelButton({ handleToggle, ...props }: CancelButtonProps) {
+  const { className } = props
+  
   return (
-    <div className="">
+    <div className={className}>
         <XIcon data-testid="x-menu" width={36} height={36} className="mr-[23px]" onClick={handleToggle} />
     </div>
   )

--- a/src/common/components/CancelButton/index.tsx
+++ b/src/common/components/CancelButton/index.tsx
@@ -1,0 +1,13 @@
+import { XIcon } from "lucide-react";
+
+interface CancelButtonProps {
+  handleToggle: () => void;
+}
+
+export default function CancelButton({ handleToggle }: CancelButtonProps) {
+  return (
+    <div className="">
+        <XIcon width={36} height={36} className="mr-[23px]" onClick={handleToggle} />
+    </div>
+  )
+}

--- a/src/main/components/MainHeader/index.tsx
+++ b/src/main/components/MainHeader/index.tsx
@@ -16,7 +16,7 @@ export default function MainHeader() {
   return (
     <header
       className={cn(
-        "relative flex h-[66px] w-full items-center justify-between",
+        "relative flex h-[66px] w-full items-center justify-between sticky top-0 z-[9999]",
         toggleMenu ? "bg-white" : "bg-main",
       )}
     >

--- a/src/main/components/WorkbookCardDetail/index.tsx
+++ b/src/main/components/WorkbookCardDetail/index.tsx
@@ -49,6 +49,7 @@ const WorkbookDetailInfoWrapper = ({
       "flex flex-col",
       "rounded-b-lg bg-black",
       "px-[21px] pb-[25px] pt-[23px]",
+      "h-[210px]"
     )}
   >
     {children}

--- a/src/problem/components/ArticleDropDown/index.tsx
+++ b/src/problem/components/ArticleDropDown/index.tsx
@@ -6,8 +6,6 @@ import ProblemArticleTemplate from "../ProblemArticleTemplate";
 export function ArticleDropDown() {
   const { getArticleId } = useProblemIdsViewModel();
 
-  console.log(getArticleId());
-  
   return (
     <div className="absolute left-0 top-[66px] z-20 h-screen w-full bg-white overflow-y-scroll px-[20px] pb-[100px]">
       <ProblemArticleTemplate articleId={getArticleId()} />

--- a/src/problem/components/ArticleDropDown/index.tsx
+++ b/src/problem/components/ArticleDropDown/index.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useProblemIdsViewModel } from "@shared/models/useProblemIdsViewModel";
+import ProblemArticleTemplate from "../ProblemArticleTemplate";
+
+export function ArticleDropDown() {
+  const { getArticleId } = useProblemIdsViewModel();
+
+  console.log(getArticleId());
+  
+  return (
+    <div className="absolute left-0 top-[66px] z-20 h-screen w-full bg-white overflow-y-scroll">
+      <ProblemArticleTemplate articleId={getArticleId()} />
+    </div>
+  );
+}

--- a/src/problem/components/ArticleDropDown/index.tsx
+++ b/src/problem/components/ArticleDropDown/index.tsx
@@ -9,7 +9,7 @@ export function ArticleDropDown() {
   console.log(getArticleId());
   
   return (
-    <div className="absolute left-0 top-[66px] z-20 h-screen w-full bg-white overflow-y-scroll">
+    <div className="absolute left-0 top-[66px] z-20 h-screen w-full bg-white overflow-y-scroll px-[20px] pb-[100px]">
       <ProblemArticleTemplate articleId={getArticleId()} />
     </div>
   );

--- a/src/problem/components/ArticleDropDownWrapper/index.tsx
+++ b/src/problem/components/ArticleDropDownWrapper/index.tsx
@@ -13,11 +13,12 @@ export default function ArticleDropDownWrapper({
   return (
     <>
       {toggleArticle && (
-        <div className="fixed inset-0 z-50 bg-white flex justify-center">
+        <div className="fixed inset-0 z-50 flex justify-center bg-white">
           <div className="relative w-full max-w-[480px] bg-white">
-            <div className="absolute top-0 right-0 p-4">
-              <CancelButton handleToggle={handleToggleArticle} />
-            </div>
+            <CancelButton
+              handleToggle={handleToggleArticle}
+              className="absolute right-0 top-0 p-4"
+            />
             <ArticleDropDown />
           </div>
         </div>

--- a/src/problem/components/ArticleDropDownWrapper/index.tsx
+++ b/src/problem/components/ArticleDropDownWrapper/index.tsx
@@ -1,0 +1,27 @@
+import { ArticleDropDown } from "../ArticleDropDown";
+import CancelButton from "@common/components/CancelButton";
+
+interface ArticleDropDownWrapperProps {
+  toggleArticle: boolean;
+  handleToggleArticle: () => void;
+}
+
+export default function ArticleDropDownWrapper({
+  toggleArticle,
+  handleToggleArticle,
+}: ArticleDropDownWrapperProps) {
+  return (
+    <>
+      {toggleArticle && (
+        <div className="fixed inset-0 z-50 bg-white flex justify-center">
+          <div className="relative w-full max-w-[480px] bg-white">
+            <div className="absolute top-0 right-0 p-4">
+              <CancelButton handleToggle={handleToggleArticle} />
+            </div>
+            <ArticleDropDown />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/problem/components/BackToArticle/BackToArticle.test.tsx
+++ b/src/problem/components/BackToArticle/BackToArticle.test.tsx
@@ -1,0 +1,62 @@
+import { beforeAll, beforeEach,describe, expect, it, vi } from "vitest";
+
+import BackToArticle from "./";
+import { BACK_TO_ARTICLE_WORDS } from "@problem/constants/backToArticle";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import QueryClientProviders from "@shared/components/queryClientProvider";
+
+// Mocking the useParams hook from next/navigation
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(),
+}));
+
+const renderWithQueryClient = () => {
+    return render(
+      <QueryClientProviders>
+        <BackToArticle />
+      </QueryClientProviders>,
+    );
+  };
+
+describe("BackToArticle Component 동작 테스트", () => {
+  beforeAll(() => {
+    vi.mock("next/navigation", async () => {
+        const actual =
+          await vi.importActual<typeof import("next/navigation")>(
+            "next/navigation",
+          );
+        return {
+          ...actual,
+          useParams: vi.fn(() => ({
+            problemId: "1",
+          })),
+        };
+      });
+  });
+
+  beforeEach(() => {
+    renderWithQueryClient();
+  });
+
+  it("아티클 다시보기 버튼 클릭 시 문제에 해당하는 아티클이 보인다.", async () => {
+    
+    expect(screen.queryByText(BACK_TO_ARTICLE_WORDS.ARTICLE)).toBeInTheDocument();
+
+    const articleLink = screen.getByText(BACK_TO_ARTICLE_WORDS.ARTICLE);
+    await userEvent.click(articleLink);
+
+    expect(screen.getByTestId("x-menu")).toBeInTheDocument();
+  });
+
+  it("X 버튼 클릭 시 아티클 뷰가 없어진다.", async () => {
+
+    const articleLink = screen.getByText(BACK_TO_ARTICLE_WORDS.ARTICLE);
+    await userEvent.click(articleLink);
+
+    const cancelButton = screen.getByTestId("x-menu"); 
+    await userEvent.click(cancelButton);
+
+    expect(screen.queryByTestId("x-menu")).not.toBeInTheDocument();
+  });
+});

--- a/src/problem/components/BackToArticle/index.tsx
+++ b/src/problem/components/BackToArticle/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useParams } from "next/navigation";
 
-import { HTMLAttributes } from "react";
+import { HTMLAttributes, useState } from "react";
 
 import { useMutationState } from "@tanstack/react-query";
 
@@ -16,10 +16,18 @@ import {
   ProblemAnswerBody,
   ProblemAnswerMuationState,
 } from "@problem/types/problemInfo";
+import { Button } from "@shared/components/ui/button";
+import ArticleDropDownWrapper from "../ArticleDropDownWrapper";
 
 interface BackToArticleProps extends HTMLAttributes<HTMLDivElement> {}
 
 export default function BackToArticle({ className }: BackToArticleProps) {
+  const [toggleArticle, setToggleArticle] = useState(false);
+
+  const handleToggleArticle = () => {
+    setToggleArticle((prev) => !prev);
+  };
+
   const { problemId } = useParams<{ problemId: string }>();
   const problemAnswersInfo = useMutationState<ProblemAnswerMuationState>({
     filters: {
@@ -40,11 +48,24 @@ export default function BackToArticle({ className }: BackToArticleProps) {
     : BACK_TO_ARTICLE_WORDS.BEFORE;
 
   return (
-    <div className={cn("flex flex-row space-x-[3px]", className, !problemAnswerInfo && "mt-[91px]" )}>
+    <div
+      className={cn(
+        "flex flex-row space-x-[3px] relative",
+        className,
+        !problemAnswerInfo && "mt-[91px]",
+      )}
+    >
+      <ArticleDropDownWrapper
+        toggleArticle={toggleArticle}
+        handleToggleArticle={handleToggleArticle}
+      />
       <span className="text-sm font-medium text-black">
         {backToArticleWords}
       </span>
-      <span className="cursor-pointer text-sm font-bold text-main underline">
+      <span
+        onClick={handleToggleArticle}
+        className="cursor-pointer text-sm font-bold text-main underline"
+      >
         {BACK_TO_ARTICLE_WORDS.ARTICLE}
       </span>
     </div>

--- a/src/problem/components/BackToArticle/index.tsx
+++ b/src/problem/components/BackToArticle/index.tsx
@@ -18,6 +18,7 @@ import {
 } from "@problem/types/problemInfo";
 import { Button } from "@shared/components/ui/button";
 import ArticleDropDownWrapper from "../ArticleDropDownWrapper";
+import { AnswerStatusModel } from "@problem/models/AnswerStatusModel";
 
 interface BackToArticleProps extends HTMLAttributes<HTMLDivElement> {}
 
@@ -41,18 +42,18 @@ export default function BackToArticle({ className }: BackToArticleProps) {
     },
   });
 
-  const problemAnswerInfo = problemAnswersInfo[0];
+  const answerStatus = new AnswerStatusModel({
+    problemAnswerInfo: problemAnswersInfo[0],
+  });
 
-  const backToArticleWords = problemAnswerInfo
-    ? BACK_TO_ARTICLE_WORDS.AFTER
-    : BACK_TO_ARTICLE_WORDS.BEFORE;
+  const backToArticleWords = answerStatus.problemSolvedStatus
 
   return (
     <div
       className={cn(
         "flex flex-row space-x-[3px] relative",
         className,
-        !problemAnswerInfo && "mt-[91px]",
+        !answerStatus.isProblemAnswerInfo && "mt-[91px]",
       )}
     >
       <ArticleDropDownWrapper

--- a/src/problem/components/BackToArticle/index.tsx
+++ b/src/problem/components/BackToArticle/index.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useParams } from "next/navigation";
+
+import { HTMLAttributes } from "react";
+
+import { useMutationState } from "@tanstack/react-query";
+
+import { ApiResponse } from "@api/fewFetch";
+
+import { cn } from "@shared/utils/cn";
+
+import { BACK_TO_ARTICLE_WORDS } from "@problem/constants/backToArticle";
+import { QUERY_KEY } from "@problem/remotes/api";
+import {
+  AnswerCheckInfo,
+  ProblemAnswerBody,
+  ProblemAnswerMuationState,
+} from "@problem/types/problemInfo";
+
+interface BackToArticleProps extends HTMLAttributes<HTMLDivElement> {}
+
+export default function BackToArticle({ className }: BackToArticleProps) {
+  const { problemId } = useParams<{ problemId: string }>();
+  const problemAnswersInfo = useMutationState<ProblemAnswerMuationState>({
+    filters: {
+      mutationKey: [QUERY_KEY.POST_PROBLEM_ANSWER, problemId],
+    },
+    select: (mutation) => {
+      return {
+        data: mutation.state.data as ApiResponse<AnswerCheckInfo>,
+        variables: mutation.state.variables as ProblemAnswerBody,
+      };
+    },
+  });
+
+  const problemAnswerInfo = problemAnswersInfo[0];
+
+  const backToArticleWords = problemAnswerInfo
+    ? BACK_TO_ARTICLE_WORDS.AFTER
+    : BACK_TO_ARTICLE_WORDS.BEFORE;
+
+  return (
+    <div className={cn("flex flex-row space-x-[3px]", className, !problemAnswerInfo && "mt-[91px]" )}>
+      <span className="text-sm font-medium text-black">
+        {backToArticleWords}
+      </span>
+      <span className="cursor-pointer text-sm font-bold text-main underline">
+        {BACK_TO_ARTICLE_WORDS.ARTICLE}
+      </span>
+    </div>
+  );
+}

--- a/src/problem/components/ProblemArticleTemplate/index.tsx
+++ b/src/problem/components/ProblemArticleTemplate/index.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useQueries } from "@tanstack/react-query";
+
+import ArticleSkeleton from "@article/components/ArticleSkeleton";
+import { ARTICLE_INFO_TYPE } from "@article/constants/articleCase";
+import { getArticleQueryOptions } from "@article/remotes/getArticleQueryOptions";
+
+interface ProblemArticleTemplateProps {
+    articleId: string
+}
+
+export default function ProblemArticleTemplate({ articleId }: ProblemArticleTemplateProps) {
+  
+  const results = useQueries({
+    queries: [
+      {
+        ...getArticleQueryOptions({ articleId }),
+        staleTime: Infinity,
+      },
+    ],
+  });
+  const {
+    data: articleInfo,
+    isLoading,
+    isError,
+  } = results[ARTICLE_INFO_TYPE.ONLY_ARTICLE];
+
+  if (isLoading || isError || !articleInfo)
+    return <ArticleSkeleton.EmailContentTemplateSkeleton />;
+
+  const { content } = articleInfo;
+
+  return (
+    <table>
+      <tbody>
+        <tr style={{}}>
+          <td dangerouslySetInnerHTML={{ __html: content }}></td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}

--- a/src/problem/components/ProblemTopbar/index.tsx
+++ b/src/problem/components/ProblemTopbar/index.tsx
@@ -12,5 +12,5 @@ export default function ProblemTopbar() {
     back();
   };
 
-  return <TopBar onClick={handleBackClick} />;
+  return <TopBar onClick={handleBackClick} className="z-[50]" />;
 }

--- a/src/problem/constants/backToArticle.ts
+++ b/src/problem/constants/backToArticle.ts
@@ -1,0 +1,5 @@
+export const BACK_TO_ARTICLE_WORDS = {
+    BEFORE: "정답을 모르겠다면?",
+    AFTER: "복습을 하고 싶다면?",
+    ARTICLE: "아티클 다시보기"
+}

--- a/src/problem/models/AnswerStatusModel.ts
+++ b/src/problem/models/AnswerStatusModel.ts
@@ -1,0 +1,24 @@
+import { BACK_TO_ARTICLE_WORDS } from "@problem/constants/backToArticle";
+import { ProblemAnswerMuationState } from "@problem/types/problemInfo";
+
+export class AnswerStatusModel {
+  constructor({
+    problemAnswerInfo,
+  }: {
+    problemAnswerInfo: ProblemAnswerMuationState | undefined;
+  }) {
+    this.problemAnswerInfo = problemAnswerInfo;
+  }
+
+  get problemSolvedStatus() {
+    return this.problemAnswerInfo
+      ? BACK_TO_ARTICLE_WORDS.AFTER
+      : BACK_TO_ARTICLE_WORDS.BEFORE;
+  }
+
+  get isProblemAnswerInfo() {
+    return Boolean(this.problemAnswerInfo);
+  }
+
+  private problemAnswerInfo: ProblemAnswerMuationState | undefined;
+}

--- a/src/shared/components/TopBar/index.tsx
+++ b/src/shared/components/TopBar/index.tsx
@@ -5,18 +5,26 @@ import { useRouter } from "next/navigation";
 import React, { HTMLAttributes } from "react";
 
 import IcBack from "public/assets/icon25/back_25.svg";
+import { cn } from "@shared/utils/cn";
 
 interface TopBarProps extends HTMLAttributes<HTMLDivElement> {}
-export default function TopBar({ onClick }: TopBarProps) {
+export default function TopBar({ onClick, className }: TopBarProps) {
   const { back } = useRouter();
 
   const onClickBackIcon = (e: React.MouseEvent<HTMLDivElement>) => {
     if (onClick) onClick(e);
-    else back()
+    else back();
   };
 
   return (
-    <div className="flex h-[66px] items-center" onClick={onClickBackIcon} data-testid="back-icon">
+    <div
+      className={cn(
+        "relative sticky top-0 flex h-[66px] items-center bg-white",
+        className,
+      )}
+      onClick={onClickBackIcon}
+      data-testid="back-icon"
+    >
       <IcBack />
     </div>
   );

--- a/src/shared/models/useProblemIdsViewModel.tsx
+++ b/src/shared/models/useProblemIdsViewModel.tsx
@@ -37,6 +37,10 @@ export const useProblemIdsViewModel = () => {
     return `${process.env.NEXT_PUBLIC_FEW_WEB}/article/${articleId}`;
   };
 
+  const getArticleId = () => {
+    return articleId
+  }
+
   return {
     setProblemIds,
     clearProblem,
@@ -48,5 +52,6 @@ export const useProblemIdsViewModel = () => {
     nextSetProblemId,
     isExistNextProblem,
     getArticlePathText,
+    getArticleId
   };
 };


### PR DESCRIPTION
## 🔥 Related Issues

https://linear.app/fewletter/issue/DEV-97/%ED%80%B4%EC%A6%88%EC%97%90%EC%84%9C-%EC%95%84%ED%8B%B0%ED%81%B4%EB%A1%9C-%EB%8B%A4%EC%8B%9C-%EB%84%98%EC%96%B4%EA%B0%80%EA%B8%B0

## 💜 작업 내용

- [x] TopBar 고정 (메인, 문제풀이, 워크북, 아티클)
- [x] 퀴즈 풀기 전과 퀴즈 풀기 후 아티클 보기 워딩 변경
- [x] 아티클 돌아가기 클릭 시 아티클 보이기

## ✅ PR Point

- 퀴즈 풀기 전 / 후 아티클 보기 워딩 처리: useMutationState 를 통해 문제 풀이 정보를 받아와 문제 풀기 전/후 워딩 처리
```
const problemAnswersInfo = useMutationState<ProblemAnswerMuationState>({
    filters: {
      mutationKey: [QUERY_KEY.POST_PROBLEM_ANSWER, problemId],
    },
    select: (mutation) => {
      return {
        data: mutation.state.data as ApiResponse<AnswerCheckInfo>,
        variables: mutation.state.variables as ProblemAnswerBody,
      };
    },
  });
```

- 아티클 돌아가기 클릭 시 아티클 보이기: 기존 문제풀이 state 를 지켜야 해서 페이지 이동 대신 toggle 형태로 처리
- `useProblemIdsViewModel` 모델에 `getArticleId` 추가 => 현재 문제에 해당하는 아티클 아이디 사용
- `CancelButton` 컴포넌트 추가하여 X 버튼 클릭 시 토글 처리 가능하도록 함

```
export default function CancelButton({ handleToggle }: CancelButtonProps) {
  return (
    <div className="">
        <XIcon data-testid="x-menu" width={36} height={36} className="mr-[23px]" onClick={handleToggle} />
    </div>
  )
}
```

## 👀 스크린샷 / GIF / 링크
- 퀴즈 풀기 전
![스크린샷 2024-08-25 오후 4 26 26](https://github.com/user-attachments/assets/c3ec9f99-8d39-4ac5-ae1a-ba4af6d75b7b)

- 퀴즈 푼 후
![스크린샷 2024-08-25 오후 4 26 50](https://github.com/user-attachments/assets/24f43b1b-1775-4f2b-bcfa-47f60ddcc63c)

- 아티클 열었을 때
![스크린샷 2024-08-25 오후 4 27 07](https://github.com/user-attachments/assets/e8be81ef-776a-4473-b1a9-941f019ada56)
